### PR TITLE
Adding explicit foreign key

### DIFF
--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -59,20 +59,29 @@ class Conversation extends Model
      *
      * @return Message
      */
-    public function getMessages($user, $perPage = 25, $page = 1, $sorting = 'asc', $columns = ['*'], $pageName = 'page')
-    {
-        return $this->messages()
-            ->join('notifications', 'notifications.data->message_id', '=', 'mc_messages.id')
-            ->where('notifications.notifiable_id', $user->id)
-            ->orderBy('mc_messages.id', $sorting)
-            ->paginate(
-                $perPage,
-                ['notifications.read_at', 'notifications.notifiable_id', 'notifications.id as notification_id',
-                    'mc_messages.*', ],
-                $pageName,
-                $page
-            );
-    }
+     public function getMessages($user, $perPage = 25, $page = 1, $sorting = 'asc', $columns = ['*'], $pageName = 'page')
+     {
+         $connection = config('database.default');
+         $driver = config("database.connections.{$connection}.driver");
+ 
+         $query  = $this->messages()
+             ->join('notifications', function($join) use ($driver) {
+                 $join->where('notifications.type', 'Musonza\Chat\Notifications\MessageSent')
+                      ->on($driver == 'sqlsrv' ? DB::raw('JSON_VALUE(data, \'$.message_id\')') :
+                          'notifications.data->message_id', '=', 'mc_messages.id');
+             })
+             ->where('notifications.notifiable_id', $user->user_id)
+             ->orderBy('mc_messages.id', $sorting)
+             ->paginate(
+                 $perPage,
+                 ['notifications.read_at', 'notifications.notifiable_id', 'notifications.id as notification_id',
+                     'mc_messages.*', ],
+                 $pageName,
+                 $page
+             );
+ 
+         return $query;
+     }
 
     /**
      * Gets the list of conversations.

--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -23,7 +23,8 @@ class Conversation extends Model
      */
     public function users()
     {
-        return $this->belongsToMany(Chat::userModel(), 'mc_conversation_user')->withTimestamps();
+        return $this->belongsToMany(Chat::userModel(), 'mc_conversation_user', 'conversation_id', 'user_id')
+                    ->withTimestamps();
     }
 
     /**


### PR DESCRIPTION
This request is to prevent errors when the User primary key is not equal to "id".
For example: Let User.php primary key = user_id. Then calling users() from a Conversation instance and then perform an Attach() call to create a conversation will try to insert the data to the user_user_id field wich does not exists.