### PR TITLE
Change order of dropping tables

### DIFF
--- a/database/migrations/create_chat_tables.php
+++ b/database/migrations/create_chat_tables.php
@@ -88,9 +88,9 @@ class CreateChatTables extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('mc_conversations');
-        Schema::dropIfExists('mc_messages');
         Schema::dropIfExists('mc_conversation_user');
         Schema::dropIfExists('mc_message_notification');
+        Schema::dropIfExists('mc_messages');
+        Schema::dropIfExists('mc_conversations');
     }
 }


### PR DESCRIPTION
php artisan migrate:refresh returns error due to mc_conversations foreign key.