### PR TITLE
Added an extra orderBy in getConversationsList

### DIFF
--- a/src/Models/Conversation.php
+++ b/src/Models/Conversation.php
@@ -300,6 +300,7 @@ class Conversation extends BaseModel
         }
 
         return $paginator->orderBy('mc_conversations.updated_at', 'DESC')
+            ->orderBy('mc_conversations.id', 'DESC')
             ->distinct('mc_conversations.id')
             ->paginate($perPage, ['mc_conversations.*'], $pageName, $page);
     }

--- a/src/Models/Conversation.php
+++ b/src/Models/Conversation.php
@@ -61,6 +61,7 @@ class Conversation extends BaseModel
      * Gets the list of conversations.
      *
      * @deprecated This will be deprecated in 4.0
+     * 
      * @param User   $user     The user
      * @param int    $perPage  The per page
      * @param int    $page     The page
@@ -152,7 +153,8 @@ class Conversation extends BaseModel
     /**
      * Sets conversation as public or private.
      *
-     * @param boolean $isPrivate
+     * @param bool $isPrivate
+     * 
      * @return Conversation
      */
     public function makePrivate($isPrivate = true)

--- a/tests/Unit/ConversationTest.php
+++ b/tests/Unit/ConversationTest.php
@@ -211,6 +211,32 @@ class ConversationTest extends TestCase
     }
 
     /** @test */
+    public function it_returns_the_correct_order_of_conversations_when_updated_at_is_duplicated() 
+    {
+        $auth = $this->users[0];
+
+        $conversation = Chat::createConversation([$auth->id, $this->users[1]->id]);
+        Chat::message('Hello-'. $conversation->id)->from($auth)->to($conversation)->send();
+
+        $conversation = Chat::createConversation([$auth->id, $this->users[2]->id]);
+        Chat::message('Hello-'. $conversation->id)->from($auth)->to($conversation)->send();
+
+        $conversation = Chat::createConversation([$auth->id, $this->users[3]->id]);
+        Chat::message('Hello-'. $conversation->id)->from($auth)->to($conversation)->send();
+
+ 
+        $conversations = Chat::conversations()->setPaginationParams(['sorting' => 'desc'])->for($auth)->limit(1)->page(1)->get();
+        $this->assertEquals('Hello-3', $conversations->items()[0]->last_message->body);
+
+        $conversations = Chat::conversations()->setPaginationParams(['sorting' => 'desc'])->for($auth)->limit(1)->page(2)->get();
+        $this->assertEquals('Hello-2', $conversations->items()[0]->last_message->body);
+
+        $conversations = Chat::conversations()->setPaginationParams(['sorting' => 'desc'])->for($auth)->limit(1)->page(3)->get();
+        $this->assertEquals('Hello-1', $conversations->items()[0]->last_message->body);
+        
+    }
+
+    /** @test */
     public function it_allows_setting_private_or_public_conversation()
     {
         $conversation = Chat::createConversation([
@@ -276,4 +302,5 @@ class ConversationTest extends TestCase
         $publicConversations = Chat::conversations()->for($this->users[0])->isPrivate(false)->get();
         $this->assertCount(1, $publicConversations);
     }
+
 }

--- a/tests/Unit/ConversationTest.php
+++ b/tests/Unit/ConversationTest.php
@@ -211,20 +211,20 @@ class ConversationTest extends TestCase
     }
 
     /** @test */
-    public function it_returns_the_correct_order_of_conversations_when_updated_at_is_duplicated() 
+    public function it_returns_the_correct_order_of_conversations_when_updated_at_is_duplicated()
     {
         $auth = $this->users[0];
 
         $conversation = Chat::createConversation([$auth->id, $this->users[1]->id]);
-        Chat::message('Hello-'. $conversation->id)->from($auth)->to($conversation)->send();
+        Chat::message('Hello-'.$conversation->id)->from($auth)->to($conversation)->send();
 
         $conversation = Chat::createConversation([$auth->id, $this->users[2]->id]);
-        Chat::message('Hello-'. $conversation->id)->from($auth)->to($conversation)->send();
+        Chat::message('Hello-'.$conversation->id)->from($auth)->to($conversation)->send();
 
         $conversation = Chat::createConversation([$auth->id, $this->users[3]->id]);
-        Chat::message('Hello-'. $conversation->id)->from($auth)->to($conversation)->send();
+        Chat::message('Hello-'.$conversation->id)->from($auth)->to($conversation)->send();
 
- 
+
         $conversations = Chat::conversations()->setPaginationParams(['sorting' => 'desc'])->for($auth)->limit(1)->page(1)->get();
         $this->assertEquals('Hello-3', $conversations->items()[0]->last_message->body);
 
@@ -233,7 +233,7 @@ class ConversationTest extends TestCase
 
         $conversations = Chat::conversations()->setPaginationParams(['sorting' => 'desc'])->for($auth)->limit(1)->page(3)->get();
         $this->assertEquals('Hello-1', $conversations->items()[0]->last_message->body);
-        
+ 
     }
 
     /** @test */
@@ -241,7 +241,7 @@ class ConversationTest extends TestCase
     {
         $conversation = Chat::createConversation([
           $this->users[0]->id,
-          $this->users[1]->id
+          $this->users[1]->id,
         ])
         ->makePrivate();
 
@@ -257,7 +257,7 @@ class ConversationTest extends TestCase
     {
         $conversation = Chat::createConversation([
           $this->users[0]->id,
-          $this->users[1]->id
+          $this->users[1]->id,
         ])
         ->makePrivate();
 
@@ -275,7 +275,7 @@ class ConversationTest extends TestCase
 
         $conversation = Chat::createConversation([
           $this->users[0]->id,
-          $this->users[1]->id
+          $this->users[1]->id,
         ])
         ->makePrivate();
 


### PR DESCRIPTION
Basically, this means Order by `'mc_conversations.updated_at' desc` but whenever there are duplicated values for update_at then order those values by `'mc_conversations.id' desc.

Fixing issue: #123 