### PR TITLE
Support laravel 5.8

### DIFF
--- a/src/Eventing/EventDispatcher.php
+++ b/src/Eventing/EventDispatcher.php
@@ -19,7 +19,7 @@ class EventDispatcher
         if (Chat::broadcasts()) {
             foreach ($events as $event) {
                 $eventName = $this->getEventName($event);
-                $this->event->fire($eventName, $event);
+                $this->event->dispatch($eventName, $event);
             }
         }
     }


### PR DESCRIPTION
The fire method (which was deprecated in Laravel 5.4) of the Illuminate/Events/Dispatcher class has been removed. You should use the dispatch method instead.