### PR TITLE
Change return type of users()

### DIFF
--- a/src/Models/Conversation.php
+++ b/src/Models/Conversation.php
@@ -4,6 +4,7 @@ namespace Musonza\Chat\Models;
 
 use Musonza\Chat\BaseModel;
 use Musonza\Chat\Chat;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Conversation extends BaseModel
 {
@@ -16,7 +17,7 @@ class Conversation extends BaseModel
     /**
      * Conversation participants.
      *
-     * @return User
+     * @return BelongsToMany
      */
     public function users()
     {


### PR DESCRIPTION
Currently, the type is `User`, which is not the return type of `Eloquent`s `belongsToMany`.
Since PHP doesn't have generics, there is no way of setting the return type to something more meaningful.