### PR TITLE
Fix Call to a member function only() on null error

### DIFF
--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -47,6 +47,10 @@ class Message extends BaseModel
     public function getSenderAttribute()
     {
         $participantModel = $this->participation->messageable;
+        
+        if (!isset($participantModel)){
+                return null;
+        }
 
         if (method_exists($participantModel, 'getParticipantDetails')) {
             return $participantModel->getParticipantDetails();

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -48,7 +48,7 @@ class Message extends BaseModel
     {
         $participantModel = $this->participation->messageable;
         
-        if (!isset($participantModel)){
+        if (!isset($participantModel)) {
                 return null;
         }
 


### PR DESCRIPTION
If a participant is deleted and you try to get the messages in a conversation you will get an error when trying to get the sender attribute. This fixes it.