### PR TITLE
Need for 'data' column in message table

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,18 @@ $message = Chat::message('http://example.com/img')
 		->to($conversation)
 		->send();
 ```
+#### To add more details about a message
+
+Sometimes you might want to add details about a message. For example, when the message type is an attachment, and you want to add details such as attachment's filename, and attachment's file url, you can call the `data()` function and pass your data as json.
+
+```php
+$message = Chat::message('Attachment 1')
+		->type('attachment')
+        ->data('{ file_name: "post_image.jpg", file_url: "http://example.com/img.jpg"}')
+		->from($model)
+		->to($conversation)
+		->send();
+```
 
 ### Get a message by id
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Sometimes you might want to add details about a message. For example, when the m
 ```php
 $message = Chat::message('Attachment 1')
 		->type('attachment')
-        ->data('{ file_name: "post_image.jpg", file_url: "http://example.com/img.jpg"}')
+		->data('{ file_name: "post_image.jpg", file_url: "http://example.com/img.jpg"}')
 		->from($model)
 		->to($conversation)
 		->send();

--- a/database/migrations/create_chat_tables.php
+++ b/database/migrations/create_chat_tables.php
@@ -44,6 +44,7 @@ class CreateChatTables extends Migration
             $table->bigInteger('conversation_id')->unsigned();
             $table->bigInteger('participation_id')->unsigned()->nullable();
             $table->string('type')->default('text');
+            $table->text('data')->nullable();
             $table->timestamps();
 
             $table->foreign('participation_id')

--- a/database/migrations/create_chat_tables.php
+++ b/database/migrations/create_chat_tables.php
@@ -68,6 +68,7 @@ class CreateChatTables extends Migration
             $table->boolean('is_seen')->default(false);
             $table->boolean('is_sender')->default(false);
             $table->boolean('flagged')->default(false);
+            $table->text('data')->nullable();
             $table->timestamps();
             $table->softDeletes();
 


### PR DESCRIPTION
A column ('data') to store details about each message was added. For instance, if our message type is an image, we can add the image link, or if it is a link we can store the link and attachment details in it. The conversation table already has this column, I think there is a need for this in the message table too.