### PR TITLE
Added 'data()' function to store details about message type in 'data' column of 'message' table

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,12 +187,12 @@ $message = Chat::message('http://example.com/img')
 ```
 #### To add more details about a message
 
-Sometimes you might want to add details about a message. For example, when the message type is an attachment, and you want to add details such as attachment's filename, and attachment's file url, you can call the `data()` function and pass your data as json.
+Sometimes you might want to add details about a message. For example, when the message type is an attachment, and you want to add details such as attachment's filename, and attachment's file url, you can call the `data()` function and pass your data as an array.
 
 ```php
 $message = Chat::message('Attachment 1')
 		->type('attachment')
-		->data('{ file_name: "post_image.jpg", file_url: "http://example.com/img.jpg"}')
+		->data(['file_name' => 'post_image.jpg', 'file_url' => 'http://example.com/post_img.jpg'])
 		->from($model)
 		->to($conversation)
 		->send();

--- a/README.md
+++ b/README.md
@@ -185,6 +185,18 @@ $message = Chat::message('http://example.com/img')
 		->to($conversation)
 		->send();
 ```
+#### To add more details about a message
+
+Sometimes you might want to add details about a message. For example, when the message type is an attachment, and you want to add details such as attachment's filename, and attachment's file url, you can call the `data()` function and pass your data as json.
+
+```php
+$message = Chat::message('Attachment 1')
+		->type('attachment')
+		->data('{ file_name: "post_image.jpg", file_url: "http://example.com/img.jpg"}')
+		->from($model)
+		->to($conversation)
+		->send();
+```
 
 ### Get a message by id
 

--- a/database/migrations/create_chat_tables.php
+++ b/database/migrations/create_chat_tables.php
@@ -44,6 +44,7 @@ class CreateChatTables extends Migration
             $table->bigInteger('conversation_id')->unsigned();
             $table->bigInteger('participation_id')->unsigned()->nullable();
             $table->string('type')->default('text');
+            $table->text('data')->nullable();
             $table->timestamps();
 
             $table->foreign('participation_id')

--- a/src/Eventing/MessageWasSent.php
+++ b/src/Eventing/MessageWasSent.php
@@ -40,6 +40,7 @@ class MessageWasSent extends Event implements ShouldBroadcast
                 'body'            => $this->message->body,
                 'conversation_id' => $this->message->conversation_id,
                 'type'            => $this->message->type,
+                'data'            => $this->message->data,
                 'created_at'      => $this->message->created_at,
                 'sender'          => $this->message->sender,
             ],

--- a/src/Messages/SendMessageCommand.php
+++ b/src/Messages/SendMessageCommand.php
@@ -10,6 +10,7 @@ class SendMessageCommand
     public $body;
     public $conversation;
     public $type;
+    public $data;
     public $participant;
 
     /**
@@ -18,11 +19,12 @@ class SendMessageCommand
      * @param Model        $sender       The sender identifier
      * @param string       $type         The message type
      */
-    public function __construct(Conversation $conversation, $body, Model $sender, $type = 'text')
+    public function __construct(Conversation $conversation, $body, Model $sender, $type = 'text', $data = '')
     {
         $this->conversation = $conversation;
         $this->body = $body;
         $this->type = $type;
+        $this->data = $data;
         $this->participant = $this->conversation->participantFromSender($sender);
     }
 }

--- a/src/Messages/SendMessageCommand.php
+++ b/src/Messages/SendMessageCommand.php
@@ -19,7 +19,7 @@ class SendMessageCommand
      * @param Model        $sender       The sender identifier
      * @param string       $type         The message type
      */
-    public function __construct(Conversation $conversation, $body, Model $sender, $type = 'text', $data = '')
+    public function __construct(Conversation $conversation, $body, Model $sender, $type = 'text', $data)
     {
         $this->conversation = $conversation;
         $this->body = $body;

--- a/src/Messages/SendMessageCommandHandler.php
+++ b/src/Messages/SendMessageCommandHandler.php
@@ -30,7 +30,7 @@ class SendMessageCommandHandler
      */
     public function handle(SendMessageCommand $command)
     {
-        $message = $this->message->send($command->conversation, $command->body, $command->participant, $command->type);
+        $message = $this->message->send($command->conversation, $command->body, $command->participant, $command->type, $command->data);
 
         $this->dispatcher->dispatch($this->message->releaseEvents());
 

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -36,6 +36,7 @@ class Message extends BaseModel
      */
     protected $casts = [
         'flagged' => 'boolean',
+        'data' => 'array'
     ];
 
     protected $appends = ['sender'];
@@ -85,7 +86,7 @@ class Message extends BaseModel
      *
      * @return Model
      */
-    public function send(Conversation $conversation, string $body, Participation $participant, string $type = 'text', string $data = ''): Model
+    public function send(Conversation $conversation, string $body, Participation $participant, string $type = 'text', array $data): Model
     {
         $message = $conversation->messages()->create([
             'body'             => $body,

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -86,7 +86,7 @@ class Message extends BaseModel
      *
      * @return Model
      */
-    public function send(Conversation $conversation, string $body, Participation $participant, string $type = 'text', array $data): Model
+    public function send(Conversation $conversation, string $body, Participation $participant, string $type = 'text', array $data = []): Model
     {
         $message = $conversation->messages()->create([
             'body'             => $body,

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -18,6 +18,7 @@ class Message extends BaseModel
         'body',
         'participation_id',
         'type',
+        'data'
     ];
 
     protected $table = ConfigurationManager::MESSAGES_TABLE;
@@ -84,12 +85,13 @@ class Message extends BaseModel
      *
      * @return Model
      */
-    public function send(Conversation $conversation, string $body, Participation $participant, string $type = 'text'): Model
+    public function send(Conversation $conversation, string $body, Participation $participant, string $type = 'text', string $data = ''): Model
     {
         $message = $conversation->messages()->create([
             'body'             => $body,
             'participation_id' => $participant->getKey(),
             'type'             => $type,
+            'data'             => $data
         ]);
 
         if (Chat::broadcasts()) {

--- a/src/Services/MessageService.php
+++ b/src/Services/MessageService.php
@@ -13,7 +13,7 @@ class MessageService
     use SetsParticipants;
 
     protected $type = 'text';
-    protected $data = '';
+    protected $data = [];
     protected $body;
     /**
      * @var CommandBus
@@ -55,7 +55,7 @@ class MessageService
         return $this;
     }
 
-    public function data(string $data)
+    public function data(array $data)
     {
         $this->data = $data;
 

--- a/src/Services/MessageService.php
+++ b/src/Services/MessageService.php
@@ -13,6 +13,7 @@ class MessageService
     use SetsParticipants;
 
     protected $type = 'text';
+    protected $data = '';
     protected $body;
     /**
      * @var CommandBus
@@ -50,6 +51,13 @@ class MessageService
     public function type(string $type)
     {
         $this->type = $type;
+
+        return $this;
+    }
+
+    public function data(string $data)
+    {
+        $this->data = $data;
 
         return $this;
     }
@@ -120,7 +128,7 @@ class MessageService
             throw new Exception('Message receiver has not been set');
         }
 
-        $command = new SendMessageCommand($this->recipient, $this->body, $this->sender, $this->type);
+        $command = new SendMessageCommand($this->recipient, $this->body, $this->sender, $this->type, $this->data);
 
         return $this->commandBus->execute($command);
     }


### PR DESCRIPTION
Sometimes you might want to add details about a message. For example, when the message type is an attachment, and you want to add details such as the attachment's filename, and attachment's file URL, you can call the 'data()' function and pass your data as JSON. A column 'data' in the message table was also created to store this data.