### PR TITLE
Customize broadcast connection and queue

### DIFF
--- a/config/musonza_chat.php
+++ b/config/musonza_chat.php
@@ -7,7 +7,7 @@ return [
      * Channel: mc-chat-conversation.2,
      * Event: Musonza\Chat\Eventing\MessageWasSent
      */
-    'broadcasts'           => false,,
+    'broadcasts'           => false,
     'broadcast_connection' => 'sync',
     'broadcast_queue'      => 'default',
 

--- a/config/musonza_chat.php
+++ b/config/musonza_chat.php
@@ -7,9 +7,9 @@ return [
      * Channel: mc-chat-conversation.2,
      * Event: Musonza\Chat\Eventing\MessageWasSent
      */
-    'broadcasts' => false,
+    'broadcasts'           => false,,
     'broadcast_connection' => 'sync',
-    'broadcast_queue' => 'default',
+    'broadcast_queue'      => 'default',
 
     /*
      * Specify the fields that you want to return each time for the sender.

--- a/config/musonza_chat.php
+++ b/config/musonza_chat.php
@@ -8,6 +8,8 @@ return [
      * Event: Musonza\Chat\Eventing\MessageWasSent
      */
     'broadcasts' => false,
+    'broadcast_connection' => 'sync',
+    'broadcast_queue' => 'default',
 
     /*
      * Specify the fields that you want to return each time for the sender.

--- a/src/Eventing/MessageWasSent.php
+++ b/src/Eventing/MessageWasSent.php
@@ -22,7 +22,7 @@ class MessageWasSent extends Event implements ShouldBroadcast
     public function __construct(Message $message)
     {
         $this->message = $message;
-        $this->connection = config('musonza_chat.broadcast_connection', 'database');
+        $this->connection = config('musonza_chat.broadcast_connection', 'sync');
         $this->queue = config('musonza_chat.broadcast_queue', 'default');
     }
 

--- a/src/Eventing/MessageWasSent.php
+++ b/src/Eventing/MessageWasSent.php
@@ -16,8 +16,8 @@ class MessageWasSent extends Event implements ShouldBroadcast
     use InteractsWithSockets;
     use SerializesModels;
     public $message;
-    public $connection = 'sync';
-    public $queue = 'default';
+    public $connection;
+    public $queue;
 
     public function __construct(Message $message)
     {

--- a/src/Eventing/MessageWasSent.php
+++ b/src/Eventing/MessageWasSent.php
@@ -16,12 +16,14 @@ class MessageWasSent extends Event implements ShouldBroadcast
     use InteractsWithSockets;
     use SerializesModels;
     public $message;
-    public $connection = config('musonza_chat.broadcast_connection', 'sync');
-    public $queue = config('musonza_chat.broadcast_queue', 'default');
+    public $connection = 'sync';
+    public $queue = 'default';
 
     public function __construct(Message $message)
     {
         $this->message = $message;
+        $this->connection = config('musonza_chat.broadcast_connection', 'database');
+        $this->queue = config('musonza_chat.broadcast_queue', 'default');
     }
 
     /**

--- a/src/Eventing/MessageWasSent.php
+++ b/src/Eventing/MessageWasSent.php
@@ -16,6 +16,8 @@ class MessageWasSent extends Event implements ShouldBroadcast
     use InteractsWithSockets;
     use SerializesModels;
     public $message;
+    public $connection = config('musonza_chat.broadcast_connection', 'sync');
+    public $queue = config('musonza_chat.broadcast_queue', 'default');
 
     public function __construct(Message $message)
     {


### PR DESCRIPTION
Added config settings to be able to define a custom broadcast connection and queue for when a message is sent, instead of using the default queue connection set by `QUEUE_CONNECTION` in the `.env` file.