### PR TITLE
Make connection on models configurable

### DIFF
--- a/src/BaseModel.php
+++ b/src/BaseModel.php
@@ -7,4 +7,9 @@ use Illuminate\Database\Eloquent\Model;
 class BaseModel extends Model
 {
     protected $tablePrefix = 'chat_';
+    
+    public function getConnectionName()
+    {
+        return config('musonza_chat.database_connection', config('database.default'));
+    }
 }


### PR DESCRIPTION
This allows developers to override default connection on package models by adding a key of `database_connection` in `config/musonza_chat.php`. I would like to use this in a project I am working on right now but I am unable to because I need to use a different database connection from the default. This change will not affect existing applications already using the default connection. No configuration changes are need for migrations, one can simply pass `--database[=DATABASE]` at the time of migration. 

Please accept my pull request so that I may use this package. Thank you!