### PR TITLE
Fix PHP 8.1 deprecation: Optional parameter $type declared before required parameter $data

### DIFF
--- a/src/Messages/SendMessageCommand.php
+++ b/src/Messages/SendMessageCommand.php
@@ -18,8 +18,9 @@ class SendMessageCommand
      * @param string       $body         The message body
      * @param Model        $sender       The sender identifier
      * @param string       $type         The message type
+     * @param array        $data         The message data
      */
-    public function __construct(Conversation $conversation, $body, Model $sender, $type = 'text', $data)
+    public function __construct(Conversation $conversation, $body, Model $sender, $type = 'text', $data = [])
     {
         $this->conversation = $conversation;
         $this->body = $body;


### PR DESCRIPTION
The PR fixes this PHP deprication: [Optional parameters specified before required parameters](https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.core.optional-before-required)

```
WARN  PHP Deprecated: Optional parameter $type declared before required parameter $data is implicitly treated as a required parameter in vendor/musonza/chat/src/Messages/SendMessageCommand.php on line 22.
````