### PR TITLE
fix: postgres exception occurred while fetching the conversation list.

### DIFF
--- a/src/Models/Conversation.php
+++ b/src/Models/Conversation.php
@@ -372,7 +372,6 @@ class Conversation extends BaseModel
             $paginator = $paginator->where('c.direct_message', (bool) $options['filters']['direct_message']);
         }
 
-
         $total = $paginator->distinct('c.id')->toBase()->getCountForPagination();
 
         $paginator = $paginator
@@ -380,7 +379,7 @@ class Conversation extends BaseModel
             ->orderBy('c.id', 'DESC')
             ->distinct('c.updated_at', 'c.id');
 
-        return $paginator->paginate($options['perPage'], [$this->tablePrefix . 'participation.*', 'c.*'], $options['pageName'], $options['page'], $total);
+        return $paginator->paginate($options['perPage'], [$this->tablePrefix.'participation.*', 'c.*'], $options['pageName'], $options['page'], $total);
     }
 
     public function unDeletedCount()

--- a/src/Models/Conversation.php
+++ b/src/Models/Conversation.php
@@ -372,11 +372,15 @@ class Conversation extends BaseModel
             $paginator = $paginator->where('c.direct_message', (bool) $options['filters']['direct_message']);
         }
 
-        return $paginator
+
+        $total = $paginator->distinct('c.id')->toBase()->getCountForPagination();
+
+        $paginator = $paginator
             ->orderBy('c.updated_at', 'DESC')
             ->orderBy('c.id', 'DESC')
-            ->distinct('c.id')
-            ->paginate($options['perPage'], [$this->tablePrefix.'participation.*', 'c.*'], $options['pageName'], $options['page']);
+            ->distinct('c.updated_at', 'c.id');
+
+        return $paginator->paginate($options['perPage'], [$this->tablePrefix . 'participation.*', 'c.*'], $options['pageName'], $options['page'], $total);
     }
 
     public function unDeletedCount()

--- a/src/Services/MessageService.php
+++ b/src/Services/MessageService.php
@@ -112,7 +112,7 @@ class MessageService
      *
      * @throws Exception
      *
-     * @return void
+     * @return Message
      */
     public function send()
     {


### PR DESCRIPTION
This pull request fixes an SQL error while fetching the conversation list via:
`Chat::conversations()->setParticipant($user)->get();`

ERROR:  SELECT DISTINCT ON expressions must match initial ORDER BY expressions.

Related issues:  
#269 
#164 