### PR TITLE
Fix MassAssignmentException in Messageable::joinConversation()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,57 +1,57 @@
 {
-    "name": "musonza/chat",
-    "description": "Chat Package for Laravel",
-    "type": "library",
-    "keywords": [
-        "laravel",
-        "chat",
-        "messaging",
-        "conversation"
-    ],
-    "require": {
-        "php": ">=8.0",
-        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
-        "spatie/laravel-fractal": "^6.0|dev-main",
-        "laravel/legacy-factories": "^1.0"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^8.0|^9.0|^10.5|^11.5.3",
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
-        "mockery/mockery": "^1.0.0"
-    },
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Tinashe Musonza",
-            "email": "tashtin263@gmail.com",
-            "role": "Developer"
-        }
-    ],
-    "autoload": {
-        "psr-4": {
-            "Musonza\\Chat\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Musonza\\Chat\\Tests\\": "tests"
-        },
-        "files": [
-            "tests/Helpers/Models.php"
-        ]
-    },
-    "scripts": {
-        "test": "phpunit"
-    },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "Musonza\\Chat\\ChatServiceProvider"
-            ],
-            "aliases": {
-                "Chat": "Musonza\\Chat\\Facades\\ChatFacade"
-            }
-        }
+  "name": "alex-chevski/chat",
+  "description": "Chat Package for Laravel",
+  "type": "library",
+  "keywords": [
+    "laravel",
+    "chat",
+    "messaging",
+    "conversation"
+  ],
+  "require": {
+    "php": ">=8.0",
+    "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0",
+    "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
+    "spatie/laravel-fractal": "^6.0|dev-main",
+    "laravel/legacy-factories": "^1.0"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^8.0|^9.0|^10.5|^11.5.3",
+    "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
+    "mockery/mockery": "^1.0.0"
+  },
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Tinashe Musonza",
+      "email": "tashtin263@gmail.com",
+      "role": "Developer"
     }
+  ],
+  "autoload": {
+    "psr-4": {
+      "Musonza\\Chat\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Musonza\\Chat\\Tests\\": "tests"
+    },
+    "files": [
+      "tests/Helpers/Models.php"
+    ]
+  },
+  "scripts": {
+    "test": "phpunit"
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Musonza\\Chat\\ChatServiceProvider"
+      ],
+      "aliases": {
+        "Chat": "Musonza\\Chat\\Facades\\ChatFacade"
+      }
+    }
+  }
 }

--- a/src/ChatServiceProvider.php
+++ b/src/ChatServiceProvider.php
@@ -22,6 +22,7 @@ class ChatServiceProvider extends ServiceProvider
     {
         $this->publishMigrations();
         $this->publishConfig();
+        $this->publishModels();
 
         if (config('musonza_chat.should_load_routes')) {
             require __DIR__.'/Http/routes.php';
@@ -74,5 +75,17 @@ class ChatServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../config' => config_path(),
         ], 'chat.config');
+    }
+
+    /**
+     * Publish package's Models file.
+     *
+     * @return void
+     */
+    public function publishModels()
+    {
+        $this->publishes([
+            __DIR__.'/../src/Models' => app_path('Models'),
+        ], 'chat.models');
     }
 }

--- a/src/Traits/Messageable.php
+++ b/src/Traits/Messageable.php
@@ -28,7 +28,7 @@ trait Messageable
             throw new InvalidDirectMessageNumberOfParticipants();
         }
 
-        $participation = new Participation;
+        $participation = new Participation();
 
         $participation->messageable_id = $this->getKey();
         $participation->messageable_type = $this->getMorphClass();

--- a/src/Traits/Messageable.php
+++ b/src/Traits/Messageable.php
@@ -28,11 +28,11 @@ trait Messageable
             throw new InvalidDirectMessageNumberOfParticipants();
         }
 
-        $participation = new Participation([
-            'messageable_id'   => $this->getKey(),
-            'messageable_type' => $this->getMorphClass(),
-            'conversation_id'  => $conversation->getKey(),
-        ]);
+        $participation = new Participation;
+
+        $participation->messageable_id = $this->getKey();
+        $participation->messageable_type = $this->getMorphClass();
+        $participation->conversation_id = $conversation->getKey();
 
         $this->participation()->save($participation);
     }


### PR DESCRIPTION
## Issue Description
When calling `joinConversation()`, a `MassAssignmentException` occurs if the `Participation` model has mass assignment protection (`fillable`/`guarded`) enabled for these fields:
- `messageable_id`
- `messageable_type`

The error triggers when creating a conversation via 
```php
$participants = [$model1, $model2,..., $modelN];

$conversation = Chat::createConversation($participants);
```

## Root Cause
Using an array in the `Participation` constructor:
```php
new Participation([...]);
```

## Solution
Replaced array-based construction with explicit property assignment:
```php
$participation = new Participation();

$participation->messageable_id = $this->getKey();
$participation->messageable_type = $this->getMorphClass();
$participation->conversation_id = $conversation->getKey();
```
## Testing
Verified on Laravel [11.45.1] with strict fillable/guarded rules. No side effects observed.

This might not be the only possible solution. I'd be happy to refine the PR if needed!