### PR TITLE
Disable the routes by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Create a Chat application for your multiple Models
 - [Installation](#installation)
 - [Usage](#usage)
   - [Adding the ability to participate to a Model](#Adding-the-ability-to-participate-to-a-Model)
+  - [Enable the routes](#enable-the-routes)
   - [Get participant details](#get-participant-details)
   - [Creating a conversation](#creating-a-conversation)
   - [Get a conversation by Id](#get-a-conversation-by-id)
@@ -100,6 +101,10 @@ class Bot extends Model
     use Messageable;
 }
 ```
+
+#### Enable the routes
+
+The package includes routes for conversations, conversation participants, and messaging. These routes are hidden by default. To enable them, change `should_load_routes` to `true`, but make sure to configure the middleware correctly. 
 
 #### Get participant details
 

--- a/config/musonza_chat.php
+++ b/config/musonza_chat.php
@@ -26,7 +26,7 @@ return [
     /*
      * Whether to load the package routes file in your application.
      */
-    'should_load_routes' => true,
+    'should_load_routes' => false,
 
     /*
      * Routes configuration

--- a/tests/Feature/ConversationControllerTest.php
+++ b/tests/Feature/ConversationControllerTest.php
@@ -16,10 +16,10 @@ class ConversationControllerTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        
+
         $this->app['config']->set('musonza_chat.should_load_routes', true);
     }
-    
+
     public function testStore()
     {
         $this->withoutExceptionHandling();

--- a/tests/Feature/ConversationControllerTest.php
+++ b/tests/Feature/ConversationControllerTest.php
@@ -13,6 +13,13 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ConversationControllerTest extends TestCase
 {
+    public function setUp()
+    {
+        parent::setUp();
+        
+        $this->app['config']->set('musonza_chat.should_load_routes', true);
+    }
+    
     public function testStore()
     {
         $this->withoutExceptionHandling();

--- a/tests/Feature/ConversationMessageControllerTest.php
+++ b/tests/Feature/ConversationMessageControllerTest.php
@@ -15,7 +15,7 @@ class ConversationMessageControllerTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        
+
         $this->app['config']->set('musonza_chat.should_load_routes', true);
     }
 

--- a/tests/Feature/ConversationMessageControllerTest.php
+++ b/tests/Feature/ConversationMessageControllerTest.php
@@ -11,7 +11,6 @@ use Musonza\Chat\Tests\TestCase;
 
 class ConversationMessageControllerTest extends TestCase
 {
-
     public function setUp()
     {
         parent::setUp();

--- a/tests/Feature/ConversationMessageControllerTest.php
+++ b/tests/Feature/ConversationMessageControllerTest.php
@@ -11,6 +11,14 @@ use Musonza\Chat\Tests\TestCase;
 
 class ConversationMessageControllerTest extends TestCase
 {
+
+    public function setUp()
+    {
+        parent::setUp();
+        
+        $this->app['config']->set('musonza_chat.should_load_routes', true);
+    }
+
     public function testStore()
     {
         $conversation = factory(Conversation::class)->create();

--- a/tests/Feature/ConversationParticipationControllerTest.php
+++ b/tests/Feature/ConversationParticipationControllerTest.php
@@ -11,6 +11,13 @@ use Musonza\Chat\Tests\TestCase;
 
 class ConversationParticipationControllerTest extends TestCase
 {
+    public function setUp()
+    {
+        parent::setUp();
+        
+        $this->app['config']->set('musonza_chat.should_load_routes', true);
+    }
+    
     public function testStore()
     {
         $conversation = factory(Conversation::class)->create();

--- a/tests/Feature/ConversationParticipationControllerTest.php
+++ b/tests/Feature/ConversationParticipationControllerTest.php
@@ -11,13 +11,14 @@ use Musonza\Chat\Tests\TestCase;
 
 class ConversationParticipationControllerTest extends TestCase
 {
+
     public function setUp()
     {
         parent::setUp();
-        
+
         $this->app['config']->set('musonza_chat.should_load_routes', true);
     }
-    
+
     public function testStore()
     {
         $conversation = factory(Conversation::class)->create();

--- a/tests/Feature/ConversationParticipationControllerTest.php
+++ b/tests/Feature/ConversationParticipationControllerTest.php
@@ -11,7 +11,6 @@ use Musonza\Chat\Tests\TestCase;
 
 class ConversationParticipationControllerTest extends TestCase
 {
-
     public function setUp()
     {
         parent::setUp();

--- a/tests/Feature/DataTransformersTest.php
+++ b/tests/Feature/DataTransformersTest.php
@@ -8,6 +8,13 @@ use Musonza\Chat\Tests\TestCase;
 
 class DataTransformersTest extends TestCase
 {
+    public function setUp()
+    {
+        parent::setUp();
+        
+        $this->app['config']->set('musonza_chat.should_load_routes', true);
+    }
+    
     public function testConversationWithoutTransformer()
     {
         $conversation = factory(Conversation::class)->create();

--- a/tests/Feature/DataTransformersTest.php
+++ b/tests/Feature/DataTransformersTest.php
@@ -8,13 +8,14 @@ use Musonza\Chat\Tests\TestCase;
 
 class DataTransformersTest extends TestCase
 {
+
     public function setUp()
     {
         parent::setUp();
-        
+
         $this->app['config']->set('musonza_chat.should_load_routes', true);
     }
-    
+
     public function testConversationWithoutTransformer()
     {
         $conversation = factory(Conversation::class)->create();

--- a/tests/Feature/DataTransformersTest.php
+++ b/tests/Feature/DataTransformersTest.php
@@ -8,7 +8,6 @@ use Musonza\Chat\Tests\TestCase;
 
 class DataTransformersTest extends TestCase
 {
-
     public function setUp()
     {
         parent::setUp();

--- a/tests/Unit/RouteTest.php
+++ b/tests/Unit/RouteTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Musonza\Chat\Tests;
+
+use Illuminate\Support\Facades\Route;
+
+class RouteTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Disable route caching and refresh routes
+        Route::flushMiddlewareGroups();
+        Route::clearResolvedInstances();
+    }
+
+    /** @test */
+    public function it_can_disable_routes()
+    {
+        // Disable route loading
+        $this->app['config']->set('musonza_chat.should_load_routes', false);
+        $this->refreshApplication();
+
+        $response = $this->get('/conversations');
+        $response->assertStatus(404);
+    }
+
+    /** @test */
+    public function it_can_enable_routes()
+    {
+        // Enable route loading
+        $this->app['config']->set('musonza_chat.should_load_routes', true);
+        $this->refreshApplication();
+
+        $response = $this->get('/conversations');
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
This pull request updates the documentation and default configuration for enabling routes in a chat application. It adds a new section to the `README.md` explaining how to enable routes and updates the default value of `should_load_routes` in the configuration file to `false`.

### Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R23): Added a new subsection, "Enable the routes," under the "Usage" section. This explains how to enable package routes by setting `should_load_routes` to `true` and configuring middleware correctly. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R23) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R105-R108)

### Configuration changes:
* [`config/musonza_chat.php`](diffhunk://#diff-c61f8120217a036286fa36e0b40999b49c18aa449f4a97eb213446f3b62f2434L29-R29): Changed the default value of `should_load_routes` from `true` to `false` to ensure that routes are not loaded by default.