### PR TITLE
Add optional message encryption feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Create a Chat application for your multiple Models
   - [Get participation entry for a Model in a conversation](#Get-participation-entry-for-a-Model-in-a-conversation)
   - [Update participation settings](#Update-participation-settings)
   - [Data Transformers](#Data-Transformers)
+  - [Message Encryption](#message-encryption)
 - [License](#license)
 
 </details>
@@ -410,7 +411,37 @@ file `musonza_chat.php` as follows:
     'participant' => \MyApp\Transformers\ParticipantTransformer::class,
 ]
 ```
-> **Note:** This only applies to responses from package routes. 
+> **Note:** This only applies to responses from package routes.
+
+#### Message Encryption
+
+You can optionally encrypt message bodies at rest using Laravel's built-in encryption. When enabled, messages are encrypted using AES-256-CBC via Laravel's `Crypt` facade.
+
+To enable encryption, set the `encrypt_messages` option in your `musonza_chat.php` config file:
+
+```php
+'encrypt_messages' => true,
+```
+
+**How it works:**
+
+- New messages are automatically encrypted before being stored in the database
+- Messages are automatically decrypted when retrieved via the model
+- Existing unencrypted messages remain readable (hybrid mode)
+- An `is_encrypted` column tracks whether each message is encrypted
+
+```php
+// Sending works the same - encryption is transparent
+$message = Chat::message('Secret message')
+    ->from($user)
+    ->to($conversation)
+    ->send();
+
+// Reading works the same - decryption is automatic
+echo $message->body; // "Secret message"
+```
+
+> **Note:** Encryption uses your application's `APP_KEY`. If you change your `APP_KEY`, previously encrypted messages will become unreadable.
 
 ## License
 

--- a/config/musonza_chat.php
+++ b/config/musonza_chat.php
@@ -10,6 +10,13 @@ return [
     'broadcasts' => false,
 
     /*
+     * Enable encryption for message bodies.
+     * When enabled, new messages will be encrypted using Laravel's Crypt facade.
+     * Existing unencrypted messages will remain readable (hybrid mode).
+     */
+    'encrypt_messages' => false,
+
+    /*
      * Specify the fields that you want to return each time for the sender.
      * If not set or empty, all the columns for the sender will be returned
      *

--- a/database/migrations/add_is_encrypted_to_messages_table.php
+++ b/database/migrations/add_is_encrypted_to_messages_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Musonza\Chat\ConfigurationManager;
+
+class AddIsEncryptedToMessagesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table(ConfigurationManager::MESSAGES_TABLE, function (Blueprint $table) {
+            $table->boolean('is_encrypted')->default(false)->after('data');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table(ConfigurationManager::MESSAGES_TABLE, function (Blueprint $table) {
+            $table->dropColumn('is_encrypted');
+        });
+    }
+}

--- a/src/Chat.php
+++ b/src/Chat.php
@@ -134,4 +134,14 @@ class Chat
 
         return (is_array($fields) && ! empty($fields)) ? $fields : null;
     }
+
+    /**
+     * Check if message encryption is enabled.
+     *
+     * @return bool
+     */
+    public static function shouldEncryptMessages(): bool
+    {
+        return (bool) config('musonza_chat.encrypt_messages', false);
+    }
 }

--- a/src/Chat.php
+++ b/src/Chat.php
@@ -137,8 +137,6 @@ class Chat
 
     /**
      * Check if message encryption is enabled.
-     *
-     * @return bool
      */
     public static function shouldEncryptMessages(): bool
     {

--- a/src/ChatServiceProvider.php
+++ b/src/ChatServiceProvider.php
@@ -62,7 +62,13 @@ class ChatServiceProvider extends ServiceProvider
         $stub      = __DIR__ . '/../database/migrations/create_chat_tables.php';
         $target    = $this->app->databasePath() . '/migrations/' . $timestamp . '_create_chat_tables.php';
 
-        $this->publishes([$stub => $target], 'chat.migrations');
+        $encryptionStub   = __DIR__ . '/../database/migrations/add_is_encrypted_to_messages_table.php';
+        $encryptionTarget = $this->app->databasePath() . '/migrations/' . $timestamp . '_add_is_encrypted_to_messages_table.php';
+
+        $this->publishes([
+            $stub           => $target,
+            $encryptionStub => $encryptionTarget,
+        ], 'chat.migrations');
     }
 
     /**

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -3,6 +3,7 @@
 namespace Musonza\Chat\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Crypt;
 use Musonza\Chat\BaseModel;
 use Musonza\Chat\Chat;
 use Musonza\Chat\ConfigurationManager;
@@ -36,8 +37,9 @@ class Message extends BaseModel
      * @var array
      */
     protected $casts = [
-        'flagged' => 'boolean',
-        'data'    => 'array',
+        'flagged'      => 'boolean',
+        'data'         => 'array',
+        'is_encrypted' => 'boolean',
     ];
 
     protected $appends = ['sender'];
@@ -45,6 +47,38 @@ class Message extends BaseModel
     public function participation()
     {
         return $this->belongsTo(Participation::class, 'participation_id');
+    }
+
+    /**
+     * Encrypt the message body if encryption is enabled.
+     *
+     * @param  string|null  $value
+     * @return void
+     */
+    public function setBodyAttribute($value)
+    {
+        if (Chat::shouldEncryptMessages() && $value !== null) {
+            $this->attributes['body'] = Crypt::encryptString($value);
+            $this->attributes['is_encrypted'] = true;
+        } else {
+            $this->attributes['body'] = $value;
+            $this->attributes['is_encrypted'] = false;
+        }
+    }
+
+    /**
+     * Decrypt the message body if it was encrypted.
+     *
+     * @param  string|null  $value
+     * @return string|null
+     */
+    public function getBodyAttribute($value)
+    {
+        if ($this->is_encrypted && $value !== null) {
+            return Crypt::decryptString($value);
+        }
+
+        return $value;
     }
 
     public function getSenderAttribute()

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -58,10 +58,10 @@ class Message extends BaseModel
     public function setBodyAttribute($value)
     {
         if (Chat::shouldEncryptMessages() && $value !== null) {
-            $this->attributes['body'] = Crypt::encryptString($value);
+            $this->attributes['body']         = Crypt::encryptString($value);
             $this->attributes['is_encrypted'] = true;
         } else {
-            $this->attributes['body'] = $value;
+            $this->attributes['body']         = $value;
             $this->attributes['is_encrypted'] = false;
         }
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,8 +3,10 @@
 namespace Musonza\Chat\Tests;
 
 require __DIR__ . '/../database/migrations/create_chat_tables.php';
+require __DIR__ . '/../database/migrations/add_is_encrypted_to_messages_table.php';
 require __DIR__ . '/Helpers/migrations.php';
 
+use AddIsEncryptedToMessagesTable;
 use CreateChatTables;
 use CreateTestTables;
 use Illuminate\Foundation\Application;
@@ -57,6 +59,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
         }
 
         (new CreateChatTables)->up();
+        (new AddIsEncryptedToMessagesTable)->up();
         (new CreateTestTables)->up();
 
         $this->withFactories(__DIR__ . '/Helpers/factories');
@@ -110,6 +113,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
     protected function tearDown(): void
     {
+        (new AddIsEncryptedToMessagesTable)->down();
         (new CreateChatTables)->down();
         (new CreateTestTables)->down();
         parent::tearDown();

--- a/tests/Unit/MessageTest.php
+++ b/tests/Unit/MessageTest.php
@@ -4,6 +4,8 @@ namespace Musonza\Chat\Tests;
 
 use Chat;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Support\Facades\DB;
+use Musonza\Chat\ConfigurationManager;
 use Musonza\Chat\Models\Conversation;
 use Musonza\Chat\Models\Message;
 use Musonza\Chat\Tests\Helpers\Models\Bot;
@@ -260,5 +262,75 @@ class MessageTest extends TestCase
         Chat::message('Hello')->from($bot)->to($conversation)->send();
 
         $this->assertSame(['name', 'bot_id'], array_keys($conversation->messages[0]->sender));
+    }
+
+    /** @test */
+    public function it_stores_message_unencrypted_when_encryption_disabled()
+    {
+        $this->app['config']->set('musonza_chat.encrypt_messages', false);
+
+        $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
+        $message      = Chat::message('Hello World')->from($this->alpha)->to($conversation)->send();
+
+        // Check the raw database value is not encrypted
+        $rawMessage = DB::table(ConfigurationManager::MESSAGES_TABLE)->where('id', $message->id)->first();
+
+        $this->assertEquals('Hello World', $rawMessage->body);
+        $this->assertFalse((bool) $rawMessage->is_encrypted);
+    }
+
+    /** @test */
+    public function it_encrypts_message_body_when_encryption_enabled()
+    {
+        $this->app['config']->set('musonza_chat.encrypt_messages', true);
+
+        $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
+        $message      = Chat::message('Secret Message')->from($this->alpha)->to($conversation)->send();
+
+        // Check the raw database value is encrypted (not plain text)
+        $rawMessage = DB::table(ConfigurationManager::MESSAGES_TABLE)->where('id', $message->id)->first();
+
+        $this->assertNotEquals('Secret Message', $rawMessage->body);
+        $this->assertTrue((bool) $rawMessage->is_encrypted);
+    }
+
+    /** @test */
+    public function it_decrypts_message_body_when_reading()
+    {
+        $this->app['config']->set('musonza_chat.encrypt_messages', true);
+
+        $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
+        $message      = Chat::message('Secret Message')->from($this->alpha)->to($conversation)->send();
+
+        // Reading the message via model should decrypt it
+        $retrievedMessage = Message::find($message->id);
+
+        $this->assertEquals('Secret Message', $retrievedMessage->body);
+    }
+
+    /** @test */
+    public function it_reads_unencrypted_messages_when_encryption_enabled()
+    {
+        // First, create a message without encryption (simulating existing data)
+        $this->app['config']->set('musonza_chat.encrypt_messages', false);
+
+        $conversation     = Chat::createConversation([$this->alpha, $this->bravo]);
+        $unencryptedMsg   = Chat::message('Old Message')->from($this->alpha)->to($conversation)->send();
+
+        // Now enable encryption
+        $this->app['config']->set('musonza_chat.encrypt_messages', true);
+
+        // Create a new encrypted message
+        $encryptedMsg = Chat::message('New Secret')->from($this->bravo)->to($conversation)->send();
+
+        // Both messages should be readable
+        $oldMessage = Message::find($unencryptedMsg->id);
+        $newMessage = Message::find($encryptedMsg->id);
+
+        $this->assertEquals('Old Message', $oldMessage->body);
+        $this->assertFalse($oldMessage->is_encrypted);
+
+        $this->assertEquals('New Secret', $newMessage->body);
+        $this->assertTrue($newMessage->is_encrypted);
     }
 }

--- a/tests/Unit/MessageTest.php
+++ b/tests/Unit/MessageTest.php
@@ -314,8 +314,8 @@ class MessageTest extends TestCase
         // First, create a message without encryption (simulating existing data)
         $this->app['config']->set('musonza_chat.encrypt_messages', false);
 
-        $conversation     = Chat::createConversation([$this->alpha, $this->bravo]);
-        $unencryptedMsg   = Chat::message('Old Message')->from($this->alpha)->to($conversation)->send();
+        $conversation   = Chat::createConversation([$this->alpha, $this->bravo]);
+        $unencryptedMsg = Chat::message('Old Message')->from($this->alpha)->to($conversation)->send();
 
         // Now enable encryption
         $this->app['config']->set('musonza_chat.encrypt_messages', true);


### PR DESCRIPTION
## Summary
- Adds transparent encryption for message bodies using Laravel's `Crypt` facade
- When enabled via config (`encrypt_messages => true`), new messages are encrypted at rest
- Existing unencrypted messages remain readable (hybrid mode) via `is_encrypted` column tracking

## Changes
- Add `encrypt_messages` config option (default: `false`)
- Add `is_encrypted` column to messages table via new migration
- Add accessor/mutator on Message model for transparent encrypt/decrypt
- Add 4 tests covering encryption, decryption, and hybrid mode

## Usage
```php
// config/musonza_chat.php
'encrypt_messages' => true,

// Messages are encrypted transparently
Chat::message('Secret')->from($user)->to($conversation)->send();
```

## Test plan
- [x] All 68 existing tests pass
- [x] 4 new encryption tests pass
- [x] Static analysis passes