### PR TITLE
Add ability to list public conversations without a participant

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Create a Chat application for your multiple Models
   - [Remove participants from a conversation](#remove-participants-from-a-conversation)
   - [Add participants to a conversation](#add-participants-to-a-conversation)
   - [Get messages in a conversation](#get-messages-in-a-conversation)
+  - [Get public conversations for discovery](#get-public-conversations-for-discovery)
   - [Get recent messages](#get-recent-messages)
   - [Get participants in a conversation](#get-participants-in-a-conversation)
   - [Get participation entry for a Model in a conversation](#Get-participation-entry-for-a-Model-in-a-conversation)
@@ -336,6 +337,21 @@ $conversations = Chat::conversations()->setParticipant($participantModel)->isDir
 // all conversations
 $conversations = Chat::conversations()->setParticipant($participantModel)->get();
 ```
+
+#### Get public conversations for discovery
+
+You can list public conversations without being a participant. This is useful for building discovery pages where users can browse and join public chat rooms (similar to Telegram public groups).
+
+```php
+// Get all public conversations (no participant required)
+$conversations = Chat::conversations()
+    ->isPrivate(false)
+    ->limit(10)
+    ->page(1)
+    ->get();
+```
+
+> **Note:** This only works for public conversations. Attempting to list private conversations without setting a participant will throw an `InvalidConversationListException`.
 
 #### Get recent messages
 

--- a/src/Exceptions/InvalidConversationListException.php
+++ b/src/Exceptions/InvalidConversationListException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Musonza\Chat\Exceptions;
+
+use Exception;
+
+class InvalidConversationListException extends Exception {}

--- a/src/Services/ConversationService.php
+++ b/src/Services/ConversationService.php
@@ -104,12 +104,19 @@ class ConversationService
      */
     public function get()
     {
-        return $this->conversation->getParticipantConversations($this->participant, [
+        $options = [
             'perPage'  => $this->perPage,
             'page'     => $this->page,
             'pageName' => 'page',
             'filters'  => $this->filters,
-        ]);
+        ];
+
+        // If no participant is set, return public conversations only
+        if (is_null($this->participant)) {
+            return $this->conversation->getPublicConversations($options);
+        }
+
+        return $this->conversation->getParticipantConversations($this->participant, $options);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Allow non-participants to discover public conversations by making `setParticipant()` optional
- Enables Telegram-style public group discovery pages
- Throws `InvalidConversationListException` if attempting to list private conversations without a participant

## Usage

```php
// List all public conversations (no participant required)
$conversations = Chat::conversations()
    ->isPrivate(false)
    ->limit(10)
    ->page(1)
    ->get();
```

## Test plan
- [x] Added test for listing public conversations without participant
- [x] Added test for listing public conversations when not a member
- [x] Added test for exception when listing private conversations without participant
- [x] Added test for pagination
- [x] Added test for last_message and participants relationships
- [x] All 73 tests pass

Closes #330