### PR TITLE
Add configurable database connection support

### DIFF
--- a/config/musonza_chat.php
+++ b/config/musonza_chat.php
@@ -2,6 +2,12 @@
 
 return [
     /*
+     * Database connection to use for chat tables.
+     * Set to null to use the default connection.
+     */
+    'database_connection' => null,
+
+    /*
      * This will allow you to broadcast an event when a message is sent
      * Example:
      * Channel: mc-chat-conversation.2,

--- a/database/migrations/add_is_encrypted_to_messages_table.php
+++ b/database/migrations/add_is_encrypted_to_messages_table.php
@@ -7,6 +7,13 @@ use Musonza\Chat\ConfigurationManager;
 
 class AddIsEncryptedToMessagesTable extends Migration
 {
+    protected function schema()
+    {
+        $connection = config('musonza_chat.database_connection');
+
+        return $connection ? Schema::connection($connection) : Schema::getFacadeRoot();
+    }
+
     /**
      * Run the migrations.
      *
@@ -14,7 +21,7 @@ class AddIsEncryptedToMessagesTable extends Migration
      */
     public function up()
     {
-        Schema::table(ConfigurationManager::MESSAGES_TABLE, function (Blueprint $table) {
+        $this->schema()->table(ConfigurationManager::MESSAGES_TABLE, function (Blueprint $table) {
             $table->boolean('is_encrypted')->default(false)->after('data');
         });
     }
@@ -26,7 +33,7 @@ class AddIsEncryptedToMessagesTable extends Migration
      */
     public function down()
     {
-        Schema::table(ConfigurationManager::MESSAGES_TABLE, function (Blueprint $table) {
+        $this->schema()->table(ConfigurationManager::MESSAGES_TABLE, function (Blueprint $table) {
             $table->dropColumn('is_encrypted');
         });
     }

--- a/database/migrations/create_chat_tables.php
+++ b/database/migrations/create_chat_tables.php
@@ -7,6 +7,13 @@ use Musonza\Chat\ConfigurationManager;
 
 class CreateChatTables extends Migration
 {
+    protected function schema()
+    {
+        $connection = config('musonza_chat.database_connection');
+
+        return $connection ? Schema::connection($connection) : Schema::getFacadeRoot();
+    }
+
     /**
      * Run the migrations.
      *
@@ -14,7 +21,7 @@ class CreateChatTables extends Migration
      */
     public function up()
     {
-        Schema::create(ConfigurationManager::CONVERSATIONS_TABLE, function (Blueprint $table) {
+        $this->schema()->create(ConfigurationManager::CONVERSATIONS_TABLE, function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->boolean('private')->default(true);
             $table->boolean('direct_message')->default(false);
@@ -22,7 +29,7 @@ class CreateChatTables extends Migration
             $table->timestamps();
         });
 
-        Schema::create(ConfigurationManager::PARTICIPATION_TABLE, function (Blueprint $table) {
+        $this->schema()->create(ConfigurationManager::PARTICIPATION_TABLE, function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->bigInteger('conversation_id')->unsigned();
             $table->bigInteger('messageable_id')->unsigned();
@@ -38,7 +45,7 @@ class CreateChatTables extends Migration
                 ->onDelete('cascade');
         });
 
-        Schema::create(ConfigurationManager::MESSAGES_TABLE, function (Blueprint $table) {
+        $this->schema()->create(ConfigurationManager::MESSAGES_TABLE, function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->text('body');
             $table->bigInteger('conversation_id')->unsigned();
@@ -58,7 +65,7 @@ class CreateChatTables extends Migration
                 ->onDelete('cascade');
         });
 
-        Schema::create(ConfigurationManager::MESSAGE_NOTIFICATIONS_TABLE, function (Blueprint $table) {
+        $this->schema()->create(ConfigurationManager::MESSAGE_NOTIFICATIONS_TABLE, function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->bigInteger('message_id')->unsigned();
             $table->bigInteger('messageable_id')->unsigned();
@@ -97,9 +104,9 @@ class CreateChatTables extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists(ConfigurationManager::MESSAGE_NOTIFICATIONS_TABLE);
-        Schema::dropIfExists(ConfigurationManager::MESSAGES_TABLE);
-        Schema::dropIfExists(ConfigurationManager::PARTICIPATION_TABLE);
-        Schema::dropIfExists(ConfigurationManager::CONVERSATIONS_TABLE);
+        $this->schema()->dropIfExists(ConfigurationManager::MESSAGE_NOTIFICATIONS_TABLE);
+        $this->schema()->dropIfExists(ConfigurationManager::MESSAGES_TABLE);
+        $this->schema()->dropIfExists(ConfigurationManager::PARTICIPATION_TABLE);
+        $this->schema()->dropIfExists(ConfigurationManager::CONVERSATIONS_TABLE);
     }
 }

--- a/src/BaseModel.php
+++ b/src/BaseModel.php
@@ -7,4 +7,13 @@ use Illuminate\Database\Eloquent\Model;
 class BaseModel extends Model
 {
     protected $tablePrefix = 'chat_';
+
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+
+        if ($connection = config('musonza_chat.database_connection')) {
+            $this->setConnection($connection);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `database_connection` config option to allow using a custom database connection for chat tables
- Updates `BaseModel` to apply the configured connection to all chat models
- Updates migrations to use the configured connection

Defaults to `null` which uses Laravel's default connection, maintaining backward compatibility.

## Usage
```php
// config/musonza_chat.php
'database_connection' => 'mysql_chat', // or any connection defined in config/database.php
```

Closes #267