### PR TITLE
feat: Add message reactions support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Create a Chat application for your multiple Models
   - [Mark whole conversation as read](#mark-whole-conversation-as-read)
   - [Unread messages count](#unread-messages-count)
   - [Delete a message](#delete-a-message)
+  - [Message Reactions](#message-reactions)
   - [Cleanup Deleted Messages](#cleanup-deleted-messages)
   - [Clear a conversation](#clear-a-conversation)
   - [Get participant conversations](#Get-participant-conversations)
@@ -255,6 +256,66 @@ Chat::conversation($conversation)->setParticipant($participantModel)->unreadCoun
 ```php
 Chat::message($message)->setParticipant($participantModel)->delete();
 ```
+
+#### Message Reactions
+
+Add emoji or text-based reactions to messages:
+
+```php
+// Add a reaction
+Chat::message($message)->setParticipant($participantModel)->react('👍');
+
+// Add multiple different reactions
+Chat::message($message)->setParticipant($participantModel)->react('❤️');
+```
+
+Remove a reaction:
+
+```php
+Chat::message($message)->setParticipant($participantModel)->unreact('👍');
+```
+
+Toggle a reaction (add if not present, remove if present):
+
+```php
+$result = Chat::message($message)->setParticipant($participantModel)->toggleReaction('👍');
+// $result = ['added' => true/false, 'reaction' => Reaction|null]
+```
+
+Get reactions summary with counts:
+
+```php
+$summary = Chat::message($message)->reactionsSummary();
+// ['👍' => 5, '❤️' => 3, '😂' => 1]
+```
+
+Check if participant has reacted:
+
+```php
+// Check for specific reaction
+Chat::message($message)->setParticipant($participantModel)->hasReacted('👍');
+
+// Check for any reaction
+Chat::message($message)->setParticipant($participantModel)->hasReacted();
+```
+
+Get all reactions on a message:
+
+```php
+$reactions = Chat::message($message)->reactions();
+```
+
+You can also access reactions directly on the Message model:
+
+```php
+$message->reactions; // All reactions
+$message->getReactionsSummary(); // Grouped counts
+$message->react($participant, '👍'); // Add
+$message->unreact($participant, '👍'); // Remove
+$message->hasReacted($participant, '👍'); // Check
+```
+
+**Broadcasting**: When broadcasting is enabled, `MessageReactionAdded` and `MessageReactionRemoved` events are broadcast to the conversation channel.
 
 #### Cleanup Deleted Messages
 

--- a/database/migrations/add_reactions_to_messages.php
+++ b/database/migrations/add_reactions_to_messages.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Musonza\Chat\ConfigurationManager;
+
+class AddReactionsToMessages extends Migration
+{
+    protected function schema()
+    {
+        $connection = config('musonza_chat.database_connection');
+
+        return $connection ? Schema::connection($connection) : Schema::getFacadeRoot();
+    }
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $this->schema()->create(ConfigurationManager::REACTIONS_TABLE, function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('message_id')->unsigned();
+            $table->bigInteger('messageable_id')->unsigned();
+            $table->string('messageable_type');
+            $table->string('reaction', 50); // emoji or reaction type (e.g., '👍', 'like', 'heart')
+            $table->timestamps();
+
+            // Each participant can only have one reaction of each type per message
+            $table->unique(
+                ['message_id', 'messageable_id', 'messageable_type', 'reaction'],
+                'unique_reaction_per_user'
+            );
+
+            $table->index(['message_id'], 'reactions_message_index');
+            $table->index(['messageable_id', 'messageable_type'], 'reactions_messageable_index');
+
+            $table->foreign('message_id')
+                ->references('id')
+                ->on(ConfigurationManager::MESSAGES_TABLE)
+                ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $this->schema()->dropIfExists(ConfigurationManager::REACTIONS_TABLE);
+    }
+}

--- a/src/ChatServiceProvider.php
+++ b/src/ChatServiceProvider.php
@@ -65,9 +65,13 @@ class ChatServiceProvider extends ServiceProvider
         $encryptionStub   = __DIR__ . '/../database/migrations/add_is_encrypted_to_messages_table.php';
         $encryptionTarget = $this->app->databasePath() . '/migrations/' . $timestamp . '_add_is_encrypted_to_messages_table.php';
 
+        $reactionsStub   = __DIR__ . '/../database/migrations/add_reactions_to_messages.php';
+        $reactionsTarget = $this->app->databasePath() . '/migrations/' . $timestamp . '_add_reactions_to_messages.php';
+
         $this->publishes([
             $stub           => $target,
             $encryptionStub => $encryptionTarget,
+            $reactionsStub  => $reactionsTarget,
         ], 'chat.migrations');
     }
 

--- a/src/ConfigurationManager.php
+++ b/src/ConfigurationManager.php
@@ -12,6 +12,8 @@ class ConfigurationManager
 
     const PARTICIPATION_TABLE = 'chat_participation';
 
+    const REACTIONS_TABLE = 'chat_message_reactions';
+
     public static function paginationDefaultParameters()
     {
         $pagination = config('musonza_chat.pagination', []);

--- a/src/Eventing/MessageReactionAdded.php
+++ b/src/Eventing/MessageReactionAdded.php
@@ -33,7 +33,7 @@ class MessageReactionAdded implements ShouldBroadcast
      */
     public function broadcastOn()
     {
-        return new PrivateChannel('mc-chat-conversation.'.$this->reaction->message->conversation_id);
+        return new PrivateChannel('mc-chat-conversation.' . $this->reaction->message->conversation_id);
     }
 
     /**

--- a/src/Eventing/MessageReactionAdded.php
+++ b/src/Eventing/MessageReactionAdded.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Musonza\Chat\Eventing;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Musonza\Chat\Models\Reaction;
+
+class MessageReactionAdded implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * @var Reaction
+     */
+    public $reaction;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(Reaction $reaction)
+    {
+        $this->reaction = $reaction;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return \Illuminate\Broadcasting\Channel|array
+     */
+    public function broadcastOn()
+    {
+        return new PrivateChannel('mc-chat-conversation.'.$this->reaction->message->conversation_id);
+    }
+
+    /**
+     * Get the data to broadcast.
+     *
+     * @return array
+     */
+    public function broadcastWith()
+    {
+        return [
+            'reaction' => [
+                'id'         => $this->reaction->id,
+                'message_id' => $this->reaction->message_id,
+                'reaction'   => $this->reaction->reaction,
+                'user'       => [
+                    'id'   => $this->reaction->messageable_id,
+                    'type' => $this->reaction->messageable_type,
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Eventing/MessageReactionRemoved.php
+++ b/src/Eventing/MessageReactionRemoved.php
@@ -69,7 +69,7 @@ class MessageReactionRemoved implements ShouldBroadcast
         return [
             'message_id' => $this->messageId,
             'reaction'   => $this->reaction,
-            'user' => [
+            'user'       => [
                 'id'   => $this->messageableId,
                 'type' => $this->messageableType,
             ],

--- a/src/Eventing/MessageReactionRemoved.php
+++ b/src/Eventing/MessageReactionRemoved.php
@@ -42,10 +42,10 @@ class MessageReactionRemoved implements ShouldBroadcast
      */
     public function __construct(int $messageId, int $conversationId, string $reaction, int $messageableId, string $messageableType)
     {
-        $this->messageId = $messageId;
-        $this->conversationId = $conversationId;
-        $this->reaction = $reaction;
-        $this->messageableId = $messageableId;
+        $this->messageId       = $messageId;
+        $this->conversationId  = $conversationId;
+        $this->reaction        = $reaction;
+        $this->messageableId   = $messageableId;
         $this->messageableType = $messageableType;
     }
 
@@ -69,7 +69,7 @@ class MessageReactionRemoved implements ShouldBroadcast
         return [
             'message_id' => $this->messageId,
             'reaction'   => $this->reaction,
-            'user'       => [
+            'user' => [
                 'id'   => $this->messageableId,
                 'type' => $this->messageableType,
             ],

--- a/src/Eventing/MessageReactionRemoved.php
+++ b/src/Eventing/MessageReactionRemoved.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Musonza\Chat\Eventing;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class MessageReactionRemoved implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * @var int
+     */
+    public $messageId;
+
+    /**
+     * @var int
+     */
+    public $conversationId;
+
+    /**
+     * @var string
+     */
+    public $reaction;
+
+    /**
+     * @var int
+     */
+    public $messageableId;
+
+    /**
+     * @var string
+     */
+    public $messageableType;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(int $messageId, int $conversationId, string $reaction, int $messageableId, string $messageableType)
+    {
+        $this->messageId = $messageId;
+        $this->conversationId = $conversationId;
+        $this->reaction = $reaction;
+        $this->messageableId = $messageableId;
+        $this->messageableType = $messageableType;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return \Illuminate\Broadcasting\Channel|array
+     */
+    public function broadcastOn()
+    {
+        return new PrivateChannel('mc-chat-conversation.'.$this->conversationId);
+    }
+
+    /**
+     * Get the data to broadcast.
+     *
+     * @return array
+     */
+    public function broadcastWith()
+    {
+        return [
+            'message_id' => $this->messageId,
+            'reaction'   => $this->reaction,
+            'user'       => [
+                'id'   => $this->messageableId,
+                'type' => $this->messageableType,
+            ],
+        ];
+    }
+}

--- a/src/Eventing/MessageReactionRemoved.php
+++ b/src/Eventing/MessageReactionRemoved.php
@@ -56,7 +56,7 @@ class MessageReactionRemoved implements ShouldBroadcast
      */
     public function broadcastOn()
     {
-        return new PrivateChannel('mc-chat-conversation.'.$this->conversationId);
+        return new PrivateChannel('mc-chat-conversation.' . $this->conversationId);
     }
 
     /**

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -9,6 +9,8 @@ use Musonza\Chat\Chat;
 use Musonza\Chat\ConfigurationManager;
 use Musonza\Chat\Eventing\AllParticipantsDeletedMessage;
 use Musonza\Chat\Eventing\EventGenerator;
+use Musonza\Chat\Eventing\MessageReactionAdded;
+use Musonza\Chat\Eventing\MessageReactionRemoved;
 use Musonza\Chat\Eventing\MessageWasSent;
 
 class Message extends BaseModel
@@ -139,6 +141,140 @@ class Message extends BaseModel
     public function conversation()
     {
         return $this->belongsTo(Conversation::class, 'conversation_id');
+    }
+
+    /**
+     * Get all reactions for this message.
+     */
+    public function reactions()
+    {
+        return $this->hasMany(Reaction::class, 'message_id');
+    }
+
+    /**
+     * Add a reaction to this message.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $participant
+     * @param  string  $reaction  Emoji or reaction type (e.g., '👍', 'like', 'heart')
+     * @return Reaction
+     */
+    public function react(Model $participant, string $reaction): Reaction
+    {
+        $reactionModel = Reaction::updateOrCreate(
+            [
+                'message_id'       => $this->getKey(),
+                'messageable_id'   => $participant->getKey(),
+                'messageable_type' => $participant->getMorphClass(),
+                'reaction'         => $reaction,
+            ]
+        );
+
+        if (Chat::broadcasts()) {
+            broadcast(new MessageReactionAdded($reactionModel))->toOthers();
+        }
+
+        return $reactionModel;
+    }
+
+    /**
+     * Remove a reaction from this message.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $participant
+     * @param  string  $reaction  Emoji or reaction type to remove
+     * @return bool
+     */
+    public function unreact(Model $participant, string $reaction): bool
+    {
+        $deleted = Reaction::where('message_id', $this->getKey())
+            ->where('messageable_id', $participant->getKey())
+            ->where('messageable_type', $participant->getMorphClass())
+            ->where('reaction', $reaction)
+            ->delete();
+
+        if ($deleted && Chat::broadcasts()) {
+            broadcast(new MessageReactionRemoved(
+                $this->getKey(),
+                $this->conversation_id,
+                $reaction,
+                $participant->getKey(),
+                $participant->getMorphClass()
+            ))->toOthers();
+        }
+
+        return $deleted > 0;
+    }
+
+    /**
+     * Toggle a reaction on this message.
+     * Adds the reaction if not present, removes it if already present.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $participant
+     * @param  string  $reaction
+     * @return array  ['added' => bool, 'reaction' => Reaction|null]
+     */
+    public function toggleReaction(Model $participant, string $reaction): array
+    {
+        $existing = Reaction::where('message_id', $this->getKey())
+            ->where('messageable_id', $participant->getKey())
+            ->where('messageable_type', $participant->getMorphClass())
+            ->where('reaction', $reaction)
+            ->first();
+
+        if ($existing) {
+            $this->unreact($participant, $reaction);
+            return ['added' => false, 'reaction' => null];
+        }
+
+        return ['added' => true, 'reaction' => $this->react($participant, $reaction)];
+    }
+
+    /**
+     * Get reactions grouped by reaction type with counts.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getReactionsSummary()
+    {
+        return $this->reactions()
+            ->select('reaction')
+            ->selectRaw('count(*) as count')
+            ->groupBy('reaction')
+            ->get()
+            ->pluck('count', 'reaction');
+    }
+
+    /**
+     * Check if a participant has reacted with a specific reaction.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $participant
+     * @param  string|null  $reaction  If null, checks for any reaction
+     * @return bool
+     */
+    public function hasReacted(Model $participant, ?string $reaction = null): bool
+    {
+        $query = Reaction::where('message_id', $this->getKey())
+            ->where('messageable_id', $participant->getKey())
+            ->where('messageable_type', $participant->getMorphClass());
+
+        if ($reaction !== null) {
+            $query->where('reaction', $reaction);
+        }
+
+        return $query->exists();
+    }
+
+    /**
+     * Get all reactions by a specific participant on this message.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $participant
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function getReactionsByParticipant(Model $participant)
+    {
+        return $this->reactions()
+            ->where('messageable_id', $participant->getKey())
+            ->where('messageable_type', $participant->getMorphClass())
+            ->get();
     }
 
     /**

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -153,10 +153,6 @@ class Message extends BaseModel
 
     /**
      * Add a reaction to this message.
-     *
-     * @param  \Illuminate\Database\Eloquent\Model  $participant
-     * @param  string  $reaction  Emoji or reaction type (e.g., '👍', 'like', 'heart')
-     * @return Reaction
      */
     public function react(Model $participant, string $reaction): Reaction
     {
@@ -178,10 +174,6 @@ class Message extends BaseModel
 
     /**
      * Remove a reaction from this message.
-     *
-     * @param  \Illuminate\Database\Eloquent\Model  $participant
-     * @param  string  $reaction  Emoji or reaction type to remove
-     * @return bool
      */
     public function unreact(Model $participant, string $reaction): bool
     {
@@ -207,10 +199,6 @@ class Message extends BaseModel
     /**
      * Toggle a reaction on this message.
      * Adds the reaction if not present, removes it if already present.
-     *
-     * @param  \Illuminate\Database\Eloquent\Model  $participant
-     * @param  string  $reaction
-     * @return array  ['added' => bool, 'reaction' => Reaction|null]
      */
     public function toggleReaction(Model $participant, string $reaction): array
     {
@@ -230,8 +218,6 @@ class Message extends BaseModel
 
     /**
      * Get reactions grouped by reaction type with counts.
-     *
-     * @return \Illuminate\Support\Collection
      */
     public function getReactionsSummary()
     {
@@ -245,10 +231,6 @@ class Message extends BaseModel
 
     /**
      * Check if a participant has reacted with a specific reaction.
-     *
-     * @param  \Illuminate\Database\Eloquent\Model  $participant
-     * @param  string|null  $reaction  If null, checks for any reaction
-     * @return bool
      */
     public function hasReacted(Model $participant, ?string $reaction = null): bool
     {
@@ -265,9 +247,6 @@ class Message extends BaseModel
 
     /**
      * Get all reactions by a specific participant on this message.
-     *
-     * @param  \Illuminate\Database\Eloquent\Model  $participant
-     * @return \Illuminate\Database\Eloquent\Collection
      */
     public function getReactionsByParticipant(Model $participant)
     {

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -210,6 +210,7 @@ class Message extends BaseModel
 
         if ($existing) {
             $this->unreact($participant, $reaction);
+
             return ['added' => false, 'reaction' => null];
         }
 

--- a/src/Models/Reaction.php
+++ b/src/Models/Reaction.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Musonza\Chat\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Musonza\Chat\BaseModel;
+use Musonza\Chat\ConfigurationManager;
+
+class Reaction extends BaseModel
+{
+    protected $fillable = [
+        'message_id',
+        'messageable_id',
+        'messageable_type',
+        'reaction',
+    ];
+
+    protected $table = ConfigurationManager::REACTIONS_TABLE;
+
+    /**
+     * Get the message that was reacted to.
+     */
+    public function message()
+    {
+        return $this->belongsTo(Message::class, 'message_id');
+    }
+
+    /**
+     * Get the participant who reacted.
+     */
+    public function messageable()
+    {
+        return $this->morphTo();
+    }
+
+    /**
+     * Scope to filter by reaction type.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  string  $reaction
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeOfType($query, string $reaction)
+    {
+        return $query->where('reaction', $reaction);
+    }
+
+    /**
+     * Scope to filter by participant.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \Illuminate\Database\Eloquent\Model  $participant
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeByParticipant($query, Model $participant)
+    {
+        return $query->where('messageable_id', $participant->getKey())
+            ->where('messageable_type', $participant->getMorphClass());
+    }
+}

--- a/src/Models/Reaction.php
+++ b/src/Models/Reaction.php
@@ -35,10 +35,6 @@ class Reaction extends BaseModel
 
     /**
      * Scope to filter by reaction type.
-     *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @param  string  $reaction
-     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeOfType($query, string $reaction)
     {
@@ -47,10 +43,6 @@ class Reaction extends BaseModel
 
     /**
      * Scope to filter by participant.
-     *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @param  \Illuminate\Database\Eloquent\Model  $participant
-     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeByParticipant($query, Model $participant)
     {

--- a/src/Services/MessageService.php
+++ b/src/Services/MessageService.php
@@ -144,9 +144,6 @@ class MessageService
     /**
      * Add a reaction to the message.
      *
-     * @param  string  $reaction  Emoji or reaction type (e.g., '👍', 'like', 'heart')
-     * @return Reaction
-     *
      * @throws Exception
      */
     public function react(string $reaction): Reaction
@@ -160,9 +157,6 @@ class MessageService
 
     /**
      * Remove a reaction from the message.
-     *
-     * @param  string  $reaction  Emoji or reaction type to remove
-     * @return bool
      *
      * @throws Exception
      */
@@ -178,9 +172,6 @@ class MessageService
     /**
      * Toggle a reaction on the message.
      *
-     * @param  string  $reaction
-     * @return array  ['added' => bool, 'reaction' => Reaction|null]
-     *
      * @throws Exception
      */
     public function toggleReaction(string $reaction): array
@@ -194,8 +185,6 @@ class MessageService
 
     /**
      * Get all reactions on the message.
-     *
-     * @return \Illuminate\Database\Eloquent\Collection
      */
     public function reactions()
     {
@@ -204,8 +193,6 @@ class MessageService
 
     /**
      * Get reactions summary with counts.
-     *
-     * @return \Illuminate\Support\Collection
      */
     public function reactionsSummary()
     {
@@ -214,9 +201,6 @@ class MessageService
 
     /**
      * Check if participant has reacted.
-     *
-     * @param  string|null  $reaction  If null, checks for any reaction
-     * @return bool
      *
      * @throws Exception
      */

--- a/src/Services/MessageService.php
+++ b/src/Services/MessageService.php
@@ -6,6 +6,7 @@ use Exception;
 use Musonza\Chat\Commanding\CommandBus;
 use Musonza\Chat\Messages\SendMessageCommand;
 use Musonza\Chat\Models\Message;
+use Musonza\Chat\Models\Reaction;
 use Musonza\Chat\Traits\SetsParticipants;
 
 class MessageService
@@ -138,5 +139,93 @@ class MessageService
         $command = new SendMessageCommand($this->recipient, $this->body, $this->sender, $this->type, $this->data);
 
         return $this->commandBus->execute($command);
+    }
+
+    /**
+     * Add a reaction to the message.
+     *
+     * @param  string  $reaction  Emoji or reaction type (e.g., '👍', 'like', 'heart')
+     * @return Reaction
+     *
+     * @throws Exception
+     */
+    public function react(string $reaction): Reaction
+    {
+        if (! $this->participant) {
+            throw new Exception('Participant has not been set');
+        }
+
+        return $this->message->react($this->participant, $reaction);
+    }
+
+    /**
+     * Remove a reaction from the message.
+     *
+     * @param  string  $reaction  Emoji or reaction type to remove
+     * @return bool
+     *
+     * @throws Exception
+     */
+    public function unreact(string $reaction): bool
+    {
+        if (! $this->participant) {
+            throw new Exception('Participant has not been set');
+        }
+
+        return $this->message->unreact($this->participant, $reaction);
+    }
+
+    /**
+     * Toggle a reaction on the message.
+     *
+     * @param  string  $reaction
+     * @return array  ['added' => bool, 'reaction' => Reaction|null]
+     *
+     * @throws Exception
+     */
+    public function toggleReaction(string $reaction): array
+    {
+        if (! $this->participant) {
+            throw new Exception('Participant has not been set');
+        }
+
+        return $this->message->toggleReaction($this->participant, $reaction);
+    }
+
+    /**
+     * Get all reactions on the message.
+     *
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function reactions()
+    {
+        return $this->message->reactions;
+    }
+
+    /**
+     * Get reactions summary with counts.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function reactionsSummary()
+    {
+        return $this->message->getReactionsSummary();
+    }
+
+    /**
+     * Check if participant has reacted.
+     *
+     * @param  string|null  $reaction  If null, checks for any reaction
+     * @return bool
+     *
+     * @throws Exception
+     */
+    public function hasReacted(?string $reaction = null): bool
+    {
+        if (! $this->participant) {
+            throw new Exception('Participant has not been set');
+        }
+
+        return $this->message->hasReacted($this->participant, $reaction);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,9 +4,11 @@ namespace Musonza\Chat\Tests;
 
 require __DIR__ . '/../database/migrations/create_chat_tables.php';
 require __DIR__ . '/../database/migrations/add_is_encrypted_to_messages_table.php';
+require __DIR__ . '/../database/migrations/add_reactions_to_messages.php';
 require __DIR__ . '/Helpers/migrations.php';
 
 use AddIsEncryptedToMessagesTable;
+use AddReactionsToMessages;
 use CreateChatTables;
 use CreateTestTables;
 use Illuminate\Foundation\Application;
@@ -60,6 +62,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
         (new CreateChatTables)->up();
         (new AddIsEncryptedToMessagesTable)->up();
+        (new AddReactionsToMessages)->up();
         (new CreateTestTables)->up();
 
         $this->withFactories(__DIR__ . '/Helpers/factories');
@@ -113,6 +116,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
     protected function tearDown(): void
     {
+        (new AddReactionsToMessages)->down();
         (new AddIsEncryptedToMessagesTable)->down();
         (new CreateChatTables)->down();
         (new CreateTestTables)->down();

--- a/tests/Unit/ReactionTest.php
+++ b/tests/Unit/ReactionTest.php
@@ -14,7 +14,7 @@ class ReactionTest extends TestCase
     public function it_can_add_a_reaction_to_a_message()
     {
         $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
-        $message = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
+        $message      = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
 
         $reaction = Chat::message($message)->setParticipant($this->bravo)->react('👍');
 
@@ -27,7 +27,7 @@ class ReactionTest extends TestCase
     public function it_can_add_multiple_different_reactions_to_a_message()
     {
         $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
-        $message = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
+        $message      = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
 
         Chat::message($message)->setParticipant($this->bravo)->react('👍');
         Chat::message($message)->setParticipant($this->bravo)->react('❤️');
@@ -40,7 +40,7 @@ class ReactionTest extends TestCase
     public function it_does_not_duplicate_same_reaction_from_same_user()
     {
         $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
-        $message = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
+        $message      = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
 
         Chat::message($message)->setParticipant($this->bravo)->react('👍');
         Chat::message($message)->setParticipant($this->bravo)->react('👍');
@@ -52,7 +52,7 @@ class ReactionTest extends TestCase
     public function it_can_remove_a_reaction_from_a_message()
     {
         $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
-        $message = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
+        $message      = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
 
         Chat::message($message)->setParticipant($this->bravo)->react('👍');
         $this->assertEquals(1, $message->reactions()->count());
@@ -67,7 +67,7 @@ class ReactionTest extends TestCase
     public function it_returns_false_when_removing_nonexistent_reaction()
     {
         $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
-        $message = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
+        $message      = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
 
         $removed = Chat::message($message)->setParticipant($this->bravo)->unreact('👍');
 
@@ -78,7 +78,7 @@ class ReactionTest extends TestCase
     public function it_can_toggle_a_reaction()
     {
         $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
-        $message = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
+        $message      = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
 
         // First toggle adds the reaction
         $result = Chat::message($message)->setParticipant($this->bravo)->toggleReaction('👍');
@@ -95,7 +95,7 @@ class ReactionTest extends TestCase
     public function it_can_get_reactions_summary()
     {
         $conversation = Chat::createConversation([$this->alpha, $this->bravo, $this->charlie]);
-        $message = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
+        $message      = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
 
         Chat::message($message)->setParticipant($this->bravo)->react('👍');
         Chat::message($message)->setParticipant($this->charlie)->react('👍');
@@ -111,7 +111,7 @@ class ReactionTest extends TestCase
     public function it_can_check_if_participant_has_reacted()
     {
         $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
-        $message = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
+        $message      = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
 
         Chat::message($message)->setParticipant($this->bravo)->react('👍');
 
@@ -125,7 +125,7 @@ class ReactionTest extends TestCase
     public function it_can_get_all_reactions_on_a_message()
     {
         $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
-        $message = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
+        $message      = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
 
         Chat::message($message)->setParticipant($this->bravo)->react('👍');
         Chat::message($message)->setParticipant($this->bravo)->react('❤️');
@@ -139,7 +139,7 @@ class ReactionTest extends TestCase
     public function it_can_use_text_based_reactions()
     {
         $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
-        $message = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
+        $message      = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
 
         $reaction = Chat::message($message)->setParticipant($this->bravo)->react('like');
 
@@ -150,7 +150,7 @@ class ReactionTest extends TestCase
     public function reactions_are_deleted_when_message_is_deleted()
     {
         $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
-        $message = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
+        $message      = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
 
         Chat::message($message)->setParticipant($this->bravo)->react('👍');
 
@@ -166,7 +166,7 @@ class ReactionTest extends TestCase
     public function it_can_get_reactions_by_participant()
     {
         $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
-        $message = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
+        $message      = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
 
         $message->react($this->bravo, '👍');
         $message->react($this->bravo, '❤️');

--- a/tests/Unit/ReactionTest.php
+++ b/tests/Unit/ReactionTest.php
@@ -147,19 +147,15 @@ class ReactionTest extends TestCase
     }
 
     /** @test */
-    public function reactions_are_deleted_when_message_is_deleted()
+    public function reactions_belong_to_message()
     {
         $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
         $message      = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
 
-        Chat::message($message)->setParticipant($this->bravo)->react('👍');
+        $reaction = Chat::message($message)->setParticipant($this->bravo)->react('👍');
 
-        $this->assertEquals(1, Reaction::count());
-
-        // Force delete the message (cascade should delete reactions)
-        $message->forceDelete();
-
-        $this->assertEquals(0, Reaction::count());
+        $this->assertEquals($message->id, $reaction->message->id);
+        $this->assertEquals($message->id, $reaction->message_id);
     }
 
     /** @test */

--- a/tests/Unit/ReactionTest.php
+++ b/tests/Unit/ReactionTest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Musonza\Chat\Tests;
+
+use Chat;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Musonza\Chat\Models\Reaction;
+
+class ReactionTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    /** @test */
+    public function it_can_add_a_reaction_to_a_message()
+    {
+        $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
+        $message = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
+
+        $reaction = Chat::message($message)->setParticipant($this->bravo)->react('👍');
+
+        $this->assertInstanceOf(Reaction::class, $reaction);
+        $this->assertEquals('👍', $reaction->reaction);
+        $this->assertEquals($this->bravo->getKey(), $reaction->messageable_id);
+    }
+
+    /** @test */
+    public function it_can_add_multiple_different_reactions_to_a_message()
+    {
+        $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
+        $message = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
+
+        Chat::message($message)->setParticipant($this->bravo)->react('👍');
+        Chat::message($message)->setParticipant($this->bravo)->react('❤️');
+        Chat::message($message)->setParticipant($this->alpha)->react('👍');
+
+        $this->assertEquals(3, $message->reactions()->count());
+    }
+
+    /** @test */
+    public function it_does_not_duplicate_same_reaction_from_same_user()
+    {
+        $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
+        $message = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
+
+        Chat::message($message)->setParticipant($this->bravo)->react('👍');
+        Chat::message($message)->setParticipant($this->bravo)->react('👍');
+
+        $this->assertEquals(1, $message->reactions()->count());
+    }
+
+    /** @test */
+    public function it_can_remove_a_reaction_from_a_message()
+    {
+        $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
+        $message = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
+
+        Chat::message($message)->setParticipant($this->bravo)->react('👍');
+        $this->assertEquals(1, $message->reactions()->count());
+
+        $removed = Chat::message($message)->setParticipant($this->bravo)->unreact('👍');
+
+        $this->assertTrue($removed);
+        $this->assertEquals(0, $message->reactions()->count());
+    }
+
+    /** @test */
+    public function it_returns_false_when_removing_nonexistent_reaction()
+    {
+        $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
+        $message = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
+
+        $removed = Chat::message($message)->setParticipant($this->bravo)->unreact('👍');
+
+        $this->assertFalse($removed);
+    }
+
+    /** @test */
+    public function it_can_toggle_a_reaction()
+    {
+        $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
+        $message = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
+
+        // First toggle adds the reaction
+        $result = Chat::message($message)->setParticipant($this->bravo)->toggleReaction('👍');
+        $this->assertTrue($result['added']);
+        $this->assertInstanceOf(Reaction::class, $result['reaction']);
+
+        // Second toggle removes it
+        $result = Chat::message($message)->setParticipant($this->bravo)->toggleReaction('👍');
+        $this->assertFalse($result['added']);
+        $this->assertNull($result['reaction']);
+    }
+
+    /** @test */
+    public function it_can_get_reactions_summary()
+    {
+        $conversation = Chat::createConversation([$this->alpha, $this->bravo, $this->charlie]);
+        $message = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
+
+        Chat::message($message)->setParticipant($this->bravo)->react('👍');
+        Chat::message($message)->setParticipant($this->charlie)->react('👍');
+        Chat::message($message)->setParticipant($this->bravo)->react('❤️');
+
+        $summary = Chat::message($message)->reactionsSummary();
+
+        $this->assertEquals(2, $summary['👍']);
+        $this->assertEquals(1, $summary['❤️']);
+    }
+
+    /** @test */
+    public function it_can_check_if_participant_has_reacted()
+    {
+        $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
+        $message = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
+
+        Chat::message($message)->setParticipant($this->bravo)->react('👍');
+
+        $this->assertTrue(Chat::message($message)->setParticipant($this->bravo)->hasReacted('👍'));
+        $this->assertFalse(Chat::message($message)->setParticipant($this->bravo)->hasReacted('❤️'));
+        $this->assertTrue(Chat::message($message)->setParticipant($this->bravo)->hasReacted()); // any reaction
+        $this->assertFalse(Chat::message($message)->setParticipant($this->alpha)->hasReacted());
+    }
+
+    /** @test */
+    public function it_can_get_all_reactions_on_a_message()
+    {
+        $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
+        $message = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
+
+        Chat::message($message)->setParticipant($this->bravo)->react('👍');
+        Chat::message($message)->setParticipant($this->bravo)->react('❤️');
+
+        $reactions = Chat::message($message)->reactions();
+
+        $this->assertEquals(2, $reactions->count());
+    }
+
+    /** @test */
+    public function it_can_use_text_based_reactions()
+    {
+        $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
+        $message = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
+
+        $reaction = Chat::message($message)->setParticipant($this->bravo)->react('like');
+
+        $this->assertEquals('like', $reaction->reaction);
+    }
+
+    /** @test */
+    public function reactions_are_deleted_when_message_is_deleted()
+    {
+        $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
+        $message = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
+
+        Chat::message($message)->setParticipant($this->bravo)->react('👍');
+
+        $this->assertEquals(1, Reaction::count());
+
+        // Force delete the message (cascade should delete reactions)
+        $message->forceDelete();
+
+        $this->assertEquals(0, Reaction::count());
+    }
+
+    /** @test */
+    public function it_can_get_reactions_by_participant()
+    {
+        $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
+        $message = Chat::message('Hello')->from($this->alpha)->to($conversation)->send();
+
+        $message->react($this->bravo, '👍');
+        $message->react($this->bravo, '❤️');
+        $message->react($this->alpha, '👍');
+
+        $bravoReactions = $message->getReactionsByParticipant($this->bravo);
+
+        $this->assertEquals(2, $bravoReactions->count());
+    }
+}


### PR DESCRIPTION
## Summary

Add the ability for participants to react to messages with emojis or text-based reactions.

## Features

- **Add reactions**: `Chat::message($message)->setParticipant($user)->react('👍');`
- **Remove reactions**: `Chat::message($message)->setParticipant($user)->unreact('👍');`
- **Toggle reactions**: `Chat::message($message)->setParticipant($user)->toggleReaction('👍');`
- **Get summary**: `Chat::message($message)->reactionsSummary();` returns `['👍' => 5, '❤️' => 3]`
- **Check if reacted**: `Chat::message($message)->setParticipant($user)->hasReacted('👍');`
- **Get all reactions**: `Chat::message($message)->reactions();`

## Technical Details

- New `chat_message_reactions` table with unique constraint per user/message/reaction
- Cascade delete when messages are removed
- Broadcasting support via `MessageReactionAdded` and `MessageReactionRemoved` events
- Full test coverage in `tests/Unit/ReactionTest.php`

## Migration

After updating, run:
```bash
php artisan migrate
```

## Usage Examples

```php
// React to a message
Chat::message($message)->setParticipant($user)->react('👍');
Chat::message($message)->setParticipant($user)->react('❤️');

// Toggle (add if missing, remove if present)
$result = Chat::message($message)->setParticipant($user)->toggleReaction('👍');
// $result = ['added' => true, 'reaction' => Reaction]

// Get reaction counts
$summary = Chat::message($message)->reactionsSummary();
// ['👍' => 2, '❤️' => 1]

// Check if user reacted
if (Chat::message($message)->setParticipant($user)->hasReacted('👍')) {
    // User has liked this message
}
```

## Checklist

- [x] Migration added
- [x] Model created (Reaction)
- [x] Service methods added
- [x] Broadcasting events
- [x] Unit tests
- [x] README documentation