### PR TITLE
feat: Add configurable broadcast connection and queue

### DIFF
--- a/config/musonza_chat.php
+++ b/config/musonza_chat.php
@@ -16,6 +16,13 @@ return [
     'broadcasts' => false,
 
     /*
+     * Customize the broadcast connection and queue for MessageWasSent event.
+     * Set to null to use the application defaults.
+     */
+    'broadcast_connection' => null,
+    'broadcast_queue'      => null,
+
+    /*
      * Enable encryption for message bodies.
      * When enabled, new messages will be encrypted using Laravel's Crypt facade.
      * Existing unencrypted messages will remain readable (hybrid mode).

--- a/src/Eventing/MessageWasSent.php
+++ b/src/Eventing/MessageWasSent.php
@@ -17,14 +17,16 @@ class MessageWasSent extends Event implements ShouldBroadcast
     use SerializesModels;
 
     public $message;
+
     public $connection;
+
     public $queue;
 
     public function __construct(Message $message)
     {
-        $this->message = $message;
+        $this->message    = $message;
         $this->connection = config('musonza_chat.broadcast_connection');
-        $this->queue = config('musonza_chat.broadcast_queue');
+        $this->queue      = config('musonza_chat.broadcast_queue');
     }
 
     /**

--- a/src/Eventing/MessageWasSent.php
+++ b/src/Eventing/MessageWasSent.php
@@ -21,6 +21,8 @@ class MessageWasSent extends Event implements ShouldBroadcast
     public function __construct(Message $message)
     {
         $this->message = $message;
+        $this->connection = config('musonza_chat.broadcast_connection');
+        $this->queue = config('musonza_chat.broadcast_queue');
     }
 
     /**

--- a/src/Eventing/MessageWasSent.php
+++ b/src/Eventing/MessageWasSent.php
@@ -17,6 +17,8 @@ class MessageWasSent extends Event implements ShouldBroadcast
     use SerializesModels;
 
     public $message;
+    public $connection;
+    public $queue;
 
     public function __construct(Message $message)
     {


### PR DESCRIPTION
## Summary
- Add `broadcast_connection` and `broadcast_queue` config options to customize the broadcast driver and queue used by the `MessageWasSent` event
- Defaults to `null` (uses application defaults) so this is a non-breaking change

Addresses the feature request in #296.

## Test plan
- [ ] Verify default behavior unchanged when config values are `null`
- [ ] Set `broadcast_connection` and `broadcast_queue` in config and verify the event uses them

🤖 Generated with [Claude Code](https://claude.com/claude-code)