### PR TITLE
fix: Pass sorting option through to conversation list queries

### DIFF
--- a/src/Models/Conversation.php
+++ b/src/Models/Conversation.php
@@ -400,9 +400,11 @@ class Conversation extends BaseModel
 
         $total = $paginator->distinct('c.id')->toBase()->getCountForPagination();
 
+        $sorting = $options['sorting'] ?? 'DESC';
+
         $paginator = $paginator
-            ->orderBy('c.updated_at', 'DESC')
-            ->orderBy('c.id', 'DESC')
+            ->orderBy('c.updated_at', $sorting)
+            ->orderBy('c.id', $sorting)
             ->distinct('c.updated_at', 'c.id');
 
         return $paginator->paginate($options['perPage'], [$this->tablePrefix . 'participation.*', 'c.*'], $options['pageName'], $options['page'], $total);
@@ -426,9 +428,11 @@ class Conversation extends BaseModel
             $query = $query->where('direct_message', (bool) $options['filters']['direct_message']);
         }
 
+        $sorting = $options['sorting'] ?? 'DESC';
+
         $query = $query
-            ->orderBy('updated_at', 'DESC')
-            ->orderBy('id', 'DESC');
+            ->orderBy('updated_at', $sorting)
+            ->orderBy('id', $sorting);
 
         return $query->paginate($options['perPage'], ['*'], $options['pageName'], $options['page']);
     }

--- a/src/Services/ConversationService.php
+++ b/src/Services/ConversationService.php
@@ -122,6 +122,7 @@ class ConversationService
             'perPage'  => $this->perPage,
             'page'     => $this->page,
             'pageName' => 'page',
+            'sorting'  => $this->sorting,
             'filters'  => $this->filters,
         ];
 


### PR DESCRIPTION
## Summary
- Passes the `sorting` parameter from the `Paginates` trait through to `getConversationsList()` and `getPublicConversationsList()` queries
- Conversation lists previously had hardcoded `DESC` ordering, ignoring the sorting option set via `setPaginationParams()`
- Closes #301

## Test plan
- [x] All 99 existing tests pass
- [ ] Verify conversation list sorting works with both `asc` and `desc` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)