### PR TITLE
feat: Add name column to conversations for filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Create a Chat application for your multiple Models
   - [Enable the routes](#enable-the-routes)
   - [Get participant details](#get-participant-details)
   - [Creating a conversation](#creating-a-conversation)
+  - [Creating a named conversation](#creating-a-named-conversation)
   - [Get a conversation by Id](#get-a-conversation-by-id)
   - [Update conversation details](#update-conversation-details)
   - [Send a text message](#send-a-text-message)
@@ -41,6 +42,7 @@ Create a Chat application for your multiple Models
   - [Add participants to a conversation](#add-participants-to-a-conversation)
   - [Get messages in a conversation](#get-messages-in-a-conversation)
   - [Get messages with cursor pagination](#get-messages-with-cursor-pagination)
+  - [Filter conversations by name](#filter-conversations-by-name)
   - [Get public conversations for discovery](#get-public-conversations-for-discovery)
   - [Get recent messages](#get-recent-messages)
   - [Get participants in a conversation](#get-participants-in-a-conversation)
@@ -162,6 +164,22 @@ $conversation = Chat::makeDirect()->createConversation($participants);
 
 > **Note:** You will not be able to add additional participants to a direct conversation. 
 Additionally you can't remove a participant from a direct conversation.
+
+#### Creating a named conversation
+
+You can assign a name to a conversation, which is useful for chatrooms or any scenario where you need to look up a conversation by a human-readable identifier.
+
+```php
+$participants = [$model1, $model2];
+
+// Create a named conversation
+$conversation = Chat::createConversation($participants, [], 'general');
+
+// The name is accessible on the conversation
+echo $conversation->name; // 'general'
+```
+
+The `name` column is nullable, so existing conversations and conversations created without a name are unaffected.
 
 #### Get a conversation by id
 ```php
@@ -436,6 +454,16 @@ $conversations = Chat::conversations()->setParticipant($participantModel)->isDir
 
 // all conversations
 $conversations = Chat::conversations()->setParticipant($participantModel)->get();
+```
+
+#### Filter conversations by name
+
+```php
+// Filter a participant's conversations by name
+$conversations = Chat::conversations()->setParticipant($participantModel)->name('general')->get();
+
+// Filter public conversations by name
+$conversations = Chat::conversations()->isPrivate(false)->name('announcements')->get();
 ```
 
 #### Get public conversations for discovery

--- a/database/migrations/add_name_to_conversations_table.php
+++ b/database/migrations/add_name_to_conversations_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Musonza\Chat\ConfigurationManager;
+
+class AddNameToConversationsTable extends Migration
+{
+    protected function schema()
+    {
+        $connection = config('musonza_chat.database_connection');
+
+        return $connection ? Schema::connection($connection) : Schema::getFacadeRoot();
+    }
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $this->schema()->table(ConfigurationManager::CONVERSATIONS_TABLE, function (Blueprint $table) {
+            $table->string('name')->nullable()->after('id');
+            $table->index('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $this->schema()->table(ConfigurationManager::CONVERSATIONS_TABLE, function (Blueprint $table) {
+            $table->dropIndex(['name']);
+            $table->dropColumn('name');
+        });
+    }
+}

--- a/src/Chat.php
+++ b/src/Chat.php
@@ -43,12 +43,13 @@ class Chat
      *
      * @return Conversation
      */
-    public function createConversation(array $participants, array $data = [])
+    public function createConversation(array $participants, array $data = [], ?string $name = null)
     {
         $payload = [
             'participants'   => $participants,
             'data'           => $data,
             'direct_message' => $this->conversationService->directMessage,
+            'name'           => $name,
         ];
 
         return $this->conversationService->start($payload);

--- a/src/Models/Conversation.php
+++ b/src/Models/Conversation.php
@@ -24,7 +24,7 @@ class Conversation extends BaseModel
 {
     protected $table = ConfigurationManager::CONVERSATIONS_TABLE;
 
-    protected $fillable = ['data', 'direct_message'];
+    protected $fillable = ['data', 'direct_message', 'name'];
 
     protected $casts = [
         'data'           => 'array',
@@ -191,7 +191,11 @@ class Conversation extends BaseModel
         }
 
         /** @var Conversation $conversation */
-        $conversation = $this->create(['data' => $payload['data'], 'direct_message' => (bool) $payload['direct_message']]);
+        $conversation = $this->create([
+            'data'           => $payload['data'],
+            'direct_message' => (bool) $payload['direct_message'],
+            'name'           => $payload['name'] ?? null,
+        ]);
 
         if ($payload['participants']) {
             $conversation->addParticipants($payload['participants']);
@@ -398,6 +402,10 @@ class Conversation extends BaseModel
             $paginator = $paginator->where('c.direct_message', (bool) $options['filters']['direct_message']);
         }
 
+        if (isset($options['filters']['name'])) {
+            $paginator = $paginator->where('c.name', $options['filters']['name']);
+        }
+
         $total = $paginator->distinct('c.id')->toBase()->getCountForPagination();
 
         $sorting = $options['sorting'] ?? 'DESC';
@@ -426,6 +434,10 @@ class Conversation extends BaseModel
 
         if (isset($options['filters']['direct_message'])) {
             $query = $query->where('direct_message', (bool) $options['filters']['direct_message']);
+        }
+
+        if (isset($options['filters']['name'])) {
+            $query = $query->where('name', $options['filters']['name']);
         }
 
         $sorting = $options['sorting'] ?? 'DESC';

--- a/src/Services/ConversationService.php
+++ b/src/Services/ConversationService.php
@@ -207,6 +207,19 @@ class ConversationService
         return $this;
     }
 
+    /**
+     * Filter conversations by name.
+     *
+     * @param  string  $name
+     * @return $this
+     */
+    public function name($name)
+    {
+        $this->filters['name'] = $name;
+
+        return $this;
+    }
+
     public function getParticipation($participant = null)
     {
         $participant = $participant ?? $this->participant;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,9 +5,11 @@ namespace Musonza\Chat\Tests;
 require __DIR__ . '/../database/migrations/create_chat_tables.php';
 require __DIR__ . '/../database/migrations/add_is_encrypted_to_messages_table.php';
 require __DIR__ . '/../database/migrations/add_reactions_to_messages.php';
+require __DIR__ . '/../database/migrations/add_name_to_conversations_table.php';
 require __DIR__ . '/Helpers/migrations.php';
 
 use AddIsEncryptedToMessagesTable;
+use AddNameToConversationsTable;
 use AddReactionsToMessages;
 use CreateChatTables;
 use CreateTestTables;
@@ -63,6 +65,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
         (new CreateChatTables)->up();
         (new AddIsEncryptedToMessagesTable)->up();
         (new AddReactionsToMessages)->up();
+        (new AddNameToConversationsTable)->up();
         (new CreateTestTables)->up();
 
         $this->withFactories(__DIR__ . '/Helpers/factories');
@@ -116,6 +119,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
     protected function tearDown(): void
     {
+        (new AddNameToConversationsTable)->down();
         (new AddReactionsToMessages)->down();
         (new AddIsEncryptedToMessagesTable)->down();
         (new CreateChatTables)->down();

--- a/tests/Unit/ConversationTest.php
+++ b/tests/Unit/ConversationTest.php
@@ -490,4 +490,45 @@ class ConversationTest extends TestCase
         $this->assertEquals('Hello public world', $publicConversations->first()->last_message->body);
         $this->assertCount(2, $publicConversations->first()->participants);
     }
+
+    public function test_it_creates_a_conversation_with_a_name()
+    {
+        $conversation = Chat::createConversation([$this->alpha, $this->bravo], [], 'general');
+
+        $this->assertEquals('general', $conversation->name);
+        $this->assertDatabaseHas($this->prefix . 'conversations', ['name' => 'general']);
+    }
+
+    public function test_it_filters_conversations_by_name()
+    {
+        Chat::createConversation([$this->alpha, $this->bravo], [], 'general');
+        Chat::createConversation([$this->alpha, $this->charlie], [], 'random');
+        Chat::createConversation([$this->alpha, $this->delta]);
+
+        $filtered = Chat::conversations()->setParticipant($this->alpha)->name('general')->get();
+        $this->assertCount(1, $filtered);
+
+        $filtered = Chat::conversations()->setParticipant($this->alpha)->name('random')->get();
+        $this->assertCount(1, $filtered);
+
+        $filtered = Chat::conversations()->setParticipant($this->alpha)->name('nonexistent')->get();
+        $this->assertCount(0, $filtered);
+    }
+
+    public function test_it_filters_public_conversations_by_name()
+    {
+        Chat::createConversation([$this->alpha, $this->bravo], [], 'announcements')->makePrivate(false);
+        Chat::createConversation([$this->alpha, $this->charlie], [], 'events')->makePrivate(false);
+
+        $filtered = Chat::conversations()->isPrivate(false)->name('announcements')->get();
+        $this->assertCount(1, $filtered);
+        $this->assertEquals('announcements', $filtered->first()->name);
+    }
+
+    public function test_it_allows_null_name()
+    {
+        $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
+
+        $this->assertNull($conversation->name);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds a nullable, indexed `name` column to `chat_conversations` table so conversations can be identified and filtered by name (useful for chatrooms)
- Adds `name()` filter method to `ConversationService` for querying conversations by name
- `Chat::createConversation()` now accepts an optional `$name` parameter

Closes #328

## Usage

```php
// Create a named conversation
Chat::createConversation([$user1, $user2], [], 'general');

// Filter by name
Chat::conversations()->setParticipant($user)->name('general')->get();

// Filter public conversations by name
Chat::conversations()->isPrivate(false)->name('announcements')->get();
```

## Test plan
- [x] Test creating a conversation with a name
- [x] Test filtering participant conversations by name
- [x] Test filtering public conversations by name
- [x] Test that name defaults to null when not provided
- [x] All 103 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)