### PR TITLE
feat: Add message type filtering for conversation messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Create a Chat application for your multiple Models
   - [Remove participants from a conversation](#remove-participants-from-a-conversation)
   - [Add participants to a conversation](#add-participants-to-a-conversation)
   - [Get messages in a conversation](#get-messages-in-a-conversation)
+  - [Filter messages by type](#filter-messages-by-type)
   - [Get messages with cursor pagination](#get-messages-with-cursor-pagination)
   - [Filter conversations by name](#filter-conversations-by-name)
   - [Get public conversations for discovery](#get-public-conversations-for-discovery)
@@ -401,6 +402,30 @@ Chat::conversation($conversation)->addParticipants([$participantModel, $particip
 
 ```php
 Chat::conversation($conversation)->setParticipant($participantModel)->getMessages()
+```
+
+#### Filter messages by type
+
+You can filter messages by their type (e.g., `text`, `image`, `attachment`) using the `ofType` method.
+
+```php
+// Get only image messages
+$messages = Chat::conversation($conversation)
+    ->setParticipant($participant)
+    ->ofType('image')
+    ->getMessages();
+
+// Get only attachment messages
+$messages = Chat::conversation($conversation)
+    ->setParticipant($participant)
+    ->ofType('attachment')
+    ->getMessages();
+
+// Also works with cursor pagination
+$messages = Chat::conversation($conversation)
+    ->setParticipant($participant)
+    ->ofType('image')
+    ->getMessagesWithCursor();
 ```
 
 #### Get messages with cursor pagination

--- a/src/Models/Conversation.php
+++ b/src/Models/Conversation.php
@@ -85,9 +85,9 @@ class Conversation extends BaseModel
      * @param  bool  $deleted
      * @return LengthAwarePaginator|HasMany|Builder
      */
-    public function getMessages(Model $participant, $paginationParams, $deleted = false)
+    public function getMessages(Model $participant, $paginationParams, $deleted = false, $type = null)
     {
-        return $this->getConversationMessages($participant, $paginationParams, $deleted);
+        return $this->getConversationMessages($participant, $paginationParams, $deleted, $type);
     }
 
     /**
@@ -100,9 +100,9 @@ class Conversation extends BaseModel
      * @param  bool  $deleted
      * @return CursorPaginator
      */
-    public function getMessagesWithCursor(Model $participant, $paginationParams, $deleted = false)
+    public function getMessagesWithCursor(Model $participant, $paginationParams, $deleted = false, $type = null)
     {
-        return $this->getConversationMessagesWithCursor($participant, $paginationParams, $deleted);
+        return $this->getConversationMessagesWithCursor($participant, $paginationParams, $deleted, $type);
     }
 
     public function getParticipantConversations($participant, array $options)
@@ -318,13 +318,17 @@ class Conversation extends BaseModel
      *
      * @return LengthAwarePaginator|HasMany|Builder
      */
-    private function getConversationMessages(Model $participant, $paginationParams, $deleted)
+    private function getConversationMessages(Model $participant, $paginationParams, $deleted, $type = null)
     {
         $messages = $this->messages()
             ->join($this->tablePrefix . 'message_notifications', $this->tablePrefix . 'message_notifications.message_id', '=', $this->tablePrefix . 'messages.id')
             ->where($this->tablePrefix . 'message_notifications.messageable_type', $participant->getMorphClass())
             ->where($this->tablePrefix . 'message_notifications.messageable_id', $participant->getKey());
         $messages = $deleted ? $messages->whereNotNull($this->tablePrefix . 'message_notifications.deleted_at') : $messages->whereNull($this->tablePrefix . 'message_notifications.deleted_at');
+
+        if ($type !== null) {
+            $messages = $messages->where($this->tablePrefix . 'messages.type', $type);
+        }
         $messages = $messages->orderBy($this->tablePrefix . 'messages.id', $paginationParams['sorting'])
             ->paginate(
                 $paginationParams['perPage'],
@@ -349,13 +353,17 @@ class Conversation extends BaseModel
      *
      * @return CursorPaginator
      */
-    private function getConversationMessagesWithCursor(Model $participant, $paginationParams, $deleted)
+    private function getConversationMessagesWithCursor(Model $participant, $paginationParams, $deleted, $type = null)
     {
         $messages = $this->messages()
             ->join($this->tablePrefix . 'message_notifications', $this->tablePrefix . 'message_notifications.message_id', '=', $this->tablePrefix . 'messages.id')
             ->where($this->tablePrefix . 'message_notifications.messageable_type', $participant->getMorphClass())
             ->where($this->tablePrefix . 'message_notifications.messageable_id', $participant->getKey());
         $messages = $deleted ? $messages->whereNotNull($this->tablePrefix . 'message_notifications.deleted_at') : $messages->whereNull($this->tablePrefix . 'message_notifications.deleted_at');
+
+        if ($type !== null) {
+            $messages = $messages->where($this->tablePrefix . 'messages.type', $type);
+        }
         $messages = $messages->orderBy($this->tablePrefix . 'messages.id', $paginationParams['sorting'])
             ->cursorPaginate(
                 $paginationParams['perPage'],

--- a/src/Services/ConversationService.php
+++ b/src/Services/ConversationService.php
@@ -18,6 +18,8 @@ class ConversationService
 
     protected $filters = [];
 
+    protected $messageType;
+
     /**
      * @var Conversation
      */
@@ -52,11 +54,23 @@ class ConversationService
     }
 
     /**
+     * Filter messages by type.
+     *
+     * @return $this
+     */
+    public function ofType(string $type)
+    {
+        $this->messageType = $type;
+
+        return $this;
+    }
+
+    /**
      * Get messages in a conversation.
      */
     public function getMessages()
     {
-        return $this->conversation->getMessages($this->participant, $this->getPaginationParams(), $this->deleted);
+        return $this->conversation->getMessages($this->participant, $this->getPaginationParams(), $this->deleted, $this->messageType);
     }
 
     /**
@@ -69,7 +83,7 @@ class ConversationService
      */
     public function getMessagesWithCursor()
     {
-        return $this->conversation->getMessagesWithCursor($this->participant, $this->getCursorPaginationParams(), $this->deleted);
+        return $this->conversation->getMessagesWithCursor($this->participant, $this->getCursorPaginationParams(), $this->deleted, $this->messageType);
     }
 
     /**

--- a/tests/Unit/ConversationTest.php
+++ b/tests/Unit/ConversationTest.php
@@ -576,4 +576,56 @@ class ConversationTest extends TestCase
         $this->assertEquals(1, $bravoCount);
         $this->assertCount(2, $partners);
     }
+
+    public function test_it_filters_messages_by_type()
+    {
+        $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
+
+        Chat::message('Hello')->type('text')->from($this->alpha)->to($conversation)->send();
+        Chat::message('photo.jpg')->type('image')->from($this->alpha)->to($conversation)->send();
+        Chat::message('file.pdf')->type('attachment')->from($this->alpha)->to($conversation)->send();
+        Chat::message('another photo')->type('image')->from($this->bravo)->to($conversation)->send();
+
+        $imageMessages = Chat::conversation($conversation)
+            ->setParticipant($this->alpha)
+            ->ofType('image')
+            ->getMessages();
+
+        $this->assertEquals(2, $imageMessages->count());
+
+        foreach ($imageMessages as $message) {
+            $this->assertEquals('image', $message->type);
+        }
+
+        $textMessages = Chat::conversation($conversation)
+            ->setParticipant($this->alpha)
+            ->ofType('text')
+            ->getMessages();
+
+        $this->assertEquals(1, $textMessages->count());
+        $this->assertEquals('text', $textMessages->first()->type);
+
+        $attachmentMessages = Chat::conversation($conversation)
+            ->setParticipant($this->alpha)
+            ->ofType('attachment')
+            ->getMessages();
+
+        $this->assertEquals(1, $attachmentMessages->count());
+        $this->assertEquals('attachment', $attachmentMessages->first()->type);
+    }
+
+    public function test_it_returns_all_messages_without_type_filter()
+    {
+        $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
+
+        Chat::message('Hello')->type('text')->from($this->alpha)->to($conversation)->send();
+        Chat::message('photo.jpg')->type('image')->from($this->alpha)->to($conversation)->send();
+        Chat::message('file.pdf')->type('attachment')->from($this->alpha)->to($conversation)->send();
+
+        $allMessages = Chat::conversation($conversation)
+            ->setParticipant($this->alpha)
+            ->getMessages();
+
+        $this->assertEquals(3, $allMessages->count());
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `ofType(string $type)` fluent method to `ConversationService` for filtering messages by type
- Works with both standard pagination (`getMessages()`) and cursor pagination (`getMessagesWithCursor()`)
- The `type` column already exists on `chat_messages` (default: 'text') — this just adds the ability to filter by it

Closes #280

## Usage

```php
// Get only image messages
$messages = Chat::conversation($conversation)
    ->setParticipant($participant)
    ->ofType('image')
    ->getMessages();

// Works with cursor pagination too
$messages = Chat::conversation($conversation)
    ->setParticipant($participant)
    ->ofType('attachment')
    ->getMessagesWithCursor();
```

## Test plan
- [x] Test filtering messages by type returns only matching messages
- [x] Test that without filter, all messages are returned
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)