### PR TITLE
feat: Add method to get all conversation partners for a model

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Create a Chat application for your multiple Models
   - [Get public conversations for discovery](#get-public-conversations-for-discovery)
   - [Get recent messages](#get-recent-messages)
   - [Get participants in a conversation](#get-participants-in-a-conversation)
+  - [Get all conversation partners](#get-all-conversation-partners)
   - [Get participation entry for a Model in a conversation](#Get-participation-entry-for-a-Model-in-a-conversation)
   - [Update participation settings](#Update-participation-settings)
   - [Data Transformers](#Data-Transformers)
@@ -516,6 +517,17 @@ To get the `conversations` simply call `$paginated->items()`
 ```php
 $participants = $conversation->getParticipants();
 ```
+
+#### Get all conversation partners
+
+Get all unique models that a user has ever been in a conversation with:
+
+```php
+// Get all models that a user has ever conversed with
+$partners = $user->conversationPartners();
+```
+
+This returns a collection of unique models, excluding the user themselves. If the same partner appears in multiple conversations, they will only be included once.
 
 #### Get participation entry for a Model in a conversation
 

--- a/src/Traits/Messageable.php
+++ b/src/Traits/Messageable.php
@@ -3,6 +3,7 @@
 namespace Musonza\Chat\Traits;
 
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Support\Collection;
 use Musonza\Chat\Exceptions\InvalidDirectMessageNumberOfParticipants;
 use Musonza\Chat\Models\Conversation;
 use Musonza\Chat\Models\Participation;
@@ -67,7 +68,7 @@ trait Messageable
     /**
      * Get all unique models that this model has ever been in a conversation with.
      *
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
     public function conversationPartners()
     {

--- a/src/Traits/Messageable.php
+++ b/src/Traits/Messageable.php
@@ -63,4 +63,27 @@ trait Messageable
             'conversation_id'  => $conversationId,
         ])->delete();
     }
+
+    /**
+     * Get all unique models that this model has ever been in a conversation with.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function conversationPartners()
+    {
+        $conversationIds = $this->participation()->pluck('conversation_id');
+
+        return Participation::whereIn('conversation_id', $conversationIds)
+            ->where(function ($query) {
+                $query->where('messageable_id', '!=', $this->getKey())
+                    ->orWhere('messageable_type', '!=', $this->getMorphClass());
+            })
+            ->with('messageable')
+            ->get()
+            ->pluck('messageable')
+            ->unique(function ($model) {
+                return $model->getMorphClass() . '-' . $model->getKey();
+            })
+            ->values();
+    }
 }

--- a/tests/Unit/ConversationTest.php
+++ b/tests/Unit/ConversationTest.php
@@ -531,4 +531,49 @@ class ConversationTest extends TestCase
 
         $this->assertNull($conversation->name);
     }
+
+    public function test_it_returns_all_unique_conversation_partners()
+    {
+        // Alpha has conversations with bravo, charlie, and delta
+        Chat::createConversation([$this->alpha, $this->bravo]);
+        Chat::createConversation([$this->alpha, $this->charlie]);
+        Chat::createConversation([$this->alpha, $this->bravo, $this->delta]);
+
+        $partners = $this->alpha->conversationPartners();
+
+        // Should return bravo, charlie, and delta
+        $this->assertCount(3, $partners);
+
+        $partnerIds = $partners->pluck('id')->sort()->values()->toArray();
+        $expectedIds = collect([$this->bravo->id, $this->charlie->id, $this->delta->id])->sort()->values()->toArray();
+
+        $this->assertEquals($expectedIds, $partnerIds);
+    }
+
+    public function test_conversation_partners_excludes_self()
+    {
+        Chat::createConversation([$this->alpha, $this->bravo]);
+
+        $partners = $this->alpha->conversationPartners();
+
+        $this->assertCount(1, $partners);
+        $this->assertEquals($this->bravo->id, $partners->first()->id);
+    }
+
+    public function test_conversation_partners_returns_unique_models_across_multiple_conversations()
+    {
+        // Bravo appears in two conversations with alpha
+        Chat::createConversation([$this->alpha, $this->bravo]);
+        Chat::createConversation([$this->alpha, $this->bravo, $this->charlie]);
+
+        $partners = $this->alpha->conversationPartners();
+
+        // Bravo should appear only once
+        $bravoCount = $partners->filter(function ($partner) {
+            return $partner->id === $this->bravo->id;
+        })->count();
+
+        $this->assertEquals(1, $bravoCount);
+        $this->assertCount(2, $partners);
+    }
 }

--- a/tests/Unit/ConversationTest.php
+++ b/tests/Unit/ConversationTest.php
@@ -544,7 +544,7 @@ class ConversationTest extends TestCase
         // Should return bravo, charlie, and delta
         $this->assertCount(3, $partners);
 
-        $partnerIds = $partners->pluck('id')->sort()->values()->toArray();
+        $partnerIds  = $partners->pluck('id')->sort()->values()->toArray();
         $expectedIds = collect([$this->bravo->id, $this->charlie->id, $this->delta->id])->sort()->values()->toArray();
 
         $this->assertEquals($expectedIds, $partnerIds);


### PR DESCRIPTION
## Summary
- Adds `conversationPartners()` method to the `Messageable` trait
- Returns a Collection of all unique models that a given model has ever been in a conversation with
- Excludes the calling model itself and deduplicates across multiple shared conversations

Closes #304

## Usage

```php
// Get all models that a user has ever conversed with
$partners = $user->conversationPartners();
```

## Test plan
- [x] Test returns all unique partners across multiple conversations
- [x] Test excludes the calling model itself
- [x] Test deduplicates partners from overlapping conversations
- [x] All existing tests continue to pass