### PR TITLE
feat: Add per-participant conversation archive (#361)

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,31 @@ Listen for `\Musonza\Chat\Eventing\AllParticipantsDeletedMessage` and
 Chat::conversation($conversation)->setParticipant($participantModel)->clear();
 ```
 
+#### Archive a conversation (per participant)
+
+Archiving is per-participant — like Gmail/Outlook — so one user can archive a thread without hiding it for the others. By default, archived conversations are excluded from a participant's listings. A new incoming message auto-unarchives the recipient (configurable).
+
+```php
+// Archive / unarchive for a single participant
+Chat::conversation($conversation)->setParticipant($participantModel)->archive();
+Chat::conversation($conversation)->setParticipant($participantModel)->unarchive();
+
+// Or directly on the model
+$conversation->archive($participantModel);
+$conversation->unarchive($participantModel);
+
+// Default listing excludes archived
+Chat::conversations()->setParticipant($participantModel)->get();
+
+// Show only archived conversations (e.g. an "Archive" inbox)
+Chat::conversations()->setParticipant($participantModel)->archived()->get();
+
+// Show both archived and non-archived together
+Chat::conversations()->setParticipant($participantModel)->withArchived()->get();
+```
+
+To disable auto-unarchive on incoming messages, set `unarchive_on_new_message => false` in `config/musonza_chat.php`.
+
 #### Get participant conversations
 
 ```php

--- a/config/musonza_chat.php
+++ b/config/musonza_chat.php
@@ -30,6 +30,13 @@ return [
     'encrypt_messages' => false,
 
     /*
+     * When true, sending a new message in a conversation automatically
+     * unarchives the recipients' participation rows (Mail-style behavior).
+     * The sender's own participation is never auto-modified.
+     */
+    'unarchive_on_new_message' => true,
+
+    /*
      * Specify the fields that you want to return each time for the sender.
      * If not set or empty, all the columns for the sender will be returned
      *

--- a/database/migrations/add_archived_at_to_participation_table.php
+++ b/database/migrations/add_archived_at_to_participation_table.php
@@ -23,7 +23,10 @@ class AddArchivedAtToParticipationTable extends Migration
     {
         $this->schema()->table(ConfigurationManager::PARTICIPATION_TABLE, function (Blueprint $table) {
             $table->timestamp('archived_at')->nullable()->after('settings');
-            $table->index(['conversation_id', 'messageable_id', 'messageable_type', 'archived_at'], 'participation_archived_index');
+            // Leads with the participant identity columns because the listing
+            // query in Conversation::getConversationsList filters by participant
+            // and archived_at across many conversations.
+            $table->index(['messageable_id', 'messageable_type', 'archived_at'], 'participation_archived_index');
         });
     }
 

--- a/database/migrations/add_archived_at_to_participation_table.php
+++ b/database/migrations/add_archived_at_to_participation_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Musonza\Chat\ConfigurationManager;
+
+class AddArchivedAtToParticipationTable extends Migration
+{
+    protected function schema()
+    {
+        $connection = config('musonza_chat.database_connection');
+
+        return $connection ? Schema::connection($connection) : Schema::getFacadeRoot();
+    }
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $this->schema()->table(ConfigurationManager::PARTICIPATION_TABLE, function (Blueprint $table) {
+            $table->timestamp('archived_at')->nullable()->after('settings');
+            $table->index(['conversation_id', 'messageable_id', 'messageable_type', 'archived_at'], 'participation_archived_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $this->schema()->table(ConfigurationManager::PARTICIPATION_TABLE, function (Blueprint $table) {
+            $table->dropIndex('participation_archived_index');
+            $table->dropColumn('archived_at');
+        });
+    }
+}

--- a/src/Models/Conversation.php
+++ b/src/Models/Conversation.php
@@ -293,6 +293,35 @@ class Conversation extends BaseModel
     }
 
     /**
+     * Archives the conversation for a single participant (Mail-style).
+     * No-op if the participant is not in the conversation or already archived.
+     */
+    public function archive(Model $participant): self
+    {
+        $participation = $this->participantFromSender($participant);
+
+        if ($participation) {
+            $participation->archive();
+        }
+
+        return $this;
+    }
+
+    /**
+     * Unarchives the conversation for a single participant.
+     */
+    public function unarchive(Model $participant): self
+    {
+        $participation = $this->participantFromSender($participant);
+
+        if ($participation) {
+            $participation->unarchive();
+        }
+
+        return $this;
+    }
+
+    /**
      * Clears participant conversation.
      */
     public function clear($participant): void
@@ -412,6 +441,14 @@ class Conversation extends BaseModel
 
         if (isset($options['filters']['name'])) {
             $paginator = $paginator->where('c.name', $options['filters']['name']);
+        }
+
+        $archivedFilter = $options['filters']['archived'] ?? false;
+
+        if ($archivedFilter === true) {
+            $paginator = $paginator->whereNotNull($this->tablePrefix . 'participation.archived_at');
+        } elseif ($archivedFilter !== 'all') {
+            $paginator = $paginator->whereNull($this->tablePrefix . 'participation.archived_at');
         }
 
         $total = $paginator->distinct('c.id')->toBase()->getCountForPagination();

--- a/src/Models/MessageNotification.php
+++ b/src/Models/MessageNotification.php
@@ -38,8 +38,8 @@ class MessageNotification extends BaseModel
 
     public static function createCustomNotifications($message, $conversation)
     {
-        $notification        = [];
-        $i                   = 0;
+        $notification            = [];
+        $i                       = 0;
         $recipientIdsToUnarchive = [];
 
         foreach ($conversation->participants as $participation) {

--- a/src/Models/MessageNotification.php
+++ b/src/Models/MessageNotification.php
@@ -38,10 +38,16 @@ class MessageNotification extends BaseModel
 
     public static function createCustomNotifications($message, $conversation)
     {
-        $notification = [];
-        $i            = 0;
+        $notification        = [];
+        $i                   = 0;
+        $recipientIdsToUnarchive = [];
+
         foreach ($conversation->participants as $participation) {
             $is_sender = ($message->participation_id == $participation->id) ? 1 : 0;
+
+            if (! $is_sender && $participation->archived_at !== null) {
+                $recipientIdsToUnarchive[] = $participation->id;
+            }
 
             $notification[] = [
                 'messageable_id'   => $participation->messageable_id,
@@ -63,6 +69,10 @@ class MessageNotification extends BaseModel
 
         if (! empty($notification)) {
             self::insert($notification);
+        }
+
+        if ($recipientIdsToUnarchive && config('musonza_chat.unarchive_on_new_message', true)) {
+            Participation::whereIn('id', $recipientIdsToUnarchive)->update(['archived_at' => null]);
         }
     }
 

--- a/src/Models/MessageNotification.php
+++ b/src/Models/MessageNotification.php
@@ -38,16 +38,10 @@ class MessageNotification extends BaseModel
 
     public static function createCustomNotifications($message, $conversation)
     {
-        $notification            = [];
-        $i                       = 0;
-        $recipientIdsToUnarchive = [];
-
+        $notification = [];
+        $i            = 0;
         foreach ($conversation->participants as $participation) {
             $is_sender = ($message->participation_id == $participation->id) ? 1 : 0;
-
-            if (! $is_sender && $participation->archived_at !== null) {
-                $recipientIdsToUnarchive[] = $participation->id;
-            }
 
             $notification[] = [
                 'messageable_id'   => $participation->messageable_id,
@@ -71,8 +65,20 @@ class MessageNotification extends BaseModel
             self::insert($notification);
         }
 
-        if ($recipientIdsToUnarchive && config('musonza_chat.unarchive_on_new_message', true)) {
-            Participation::whereIn('id', $recipientIdsToUnarchive)->update(['archived_at' => null]);
+        if (config('musonza_chat.unarchive_on_new_message', true)) {
+            // Unarchive all recipients in one query, sourced from the DB rather
+            // than the (possibly stale) in-memory $conversation->participants
+            // collection. The sender's own row is excluded; if there is no
+            // sender (system message with null participation_id) all archived
+            // participations are restored.
+            $query = Participation::where('conversation_id', $conversation->id)
+                ->whereNotNull('archived_at');
+
+            if ($message->participation_id !== null) {
+                $query->where('id', '!=', $message->participation_id);
+            }
+
+            $query->update(['archived_at' => null]);
         }
     }
 

--- a/src/Models/Participation.php
+++ b/src/Models/Participation.php
@@ -2,6 +2,7 @@
 
 namespace Musonza\Chat\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 // use Illuminate\Database\Eloquent\SoftDeletes;
 use Musonza\Chat\BaseModel;
@@ -16,10 +17,12 @@ class Participation extends BaseModel
     protected $fillable = [
         'conversation_id',
         'settings',
+        'archived_at',
     ];
 
     protected $casts = [
-        'settings' => 'array',
+        'settings'    => 'array',
+        'archived_at' => 'datetime',
     ];
 
     /**
@@ -35,5 +38,40 @@ class Participation extends BaseModel
     public function messageable()
     {
         return $this->morphTo()->with('participation');
+    }
+
+    public function archive(): self
+    {
+        if ($this->archived_at === null) {
+            $this->archived_at = $this->freshTimestamp();
+            $this->save();
+        }
+
+        return $this;
+    }
+
+    public function unarchive(): self
+    {
+        if ($this->archived_at !== null) {
+            $this->archived_at = null;
+            $this->save();
+        }
+
+        return $this;
+    }
+
+    public function isArchived(): bool
+    {
+        return $this->archived_at !== null;
+    }
+
+    public function scopeArchived(Builder $query): Builder
+    {
+        return $query->whereNotNull($this->getTable() . '.archived_at');
+    }
+
+    public function scopeNotArchived(Builder $query): Builder
+    {
+        return $query->whereNull($this->getTable() . '.archived_at');
     }
 }

--- a/src/Services/ConversationService.php
+++ b/src/Services/ConversationService.php
@@ -242,4 +242,46 @@ class ConversationService
             ->where('conversation_id', $this->conversation->getKey())
             ->first();
     }
+
+    /**
+     * Filter to only archived conversations for the participant.
+     * Pass false to filter to only non-archived (the default behavior).
+     *
+     * @param  bool  $archived
+     * @return $this
+     */
+    public function archived($archived = true)
+    {
+        $this->filters['archived'] = (bool) $archived;
+
+        return $this;
+    }
+
+    /**
+     * Include both archived and non-archived conversations.
+     *
+     * @return $this
+     */
+    public function withArchived()
+    {
+        $this->filters['archived'] = 'all';
+
+        return $this;
+    }
+
+    /**
+     * Archive the current conversation for the set participant.
+     */
+    public function archive(): Conversation
+    {
+        return $this->conversation->archive($this->participant);
+    }
+
+    /**
+     * Unarchive the current conversation for the set participant.
+     */
+    public function unarchive(): Conversation
+    {
+        return $this->conversation->unarchive($this->participant);
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,8 +6,10 @@ require __DIR__ . '/../database/migrations/create_chat_tables.php';
 require __DIR__ . '/../database/migrations/add_is_encrypted_to_messages_table.php';
 require __DIR__ . '/../database/migrations/add_reactions_to_messages.php';
 require __DIR__ . '/../database/migrations/add_name_to_conversations_table.php';
+require __DIR__ . '/../database/migrations/add_archived_at_to_participation_table.php';
 require __DIR__ . '/Helpers/migrations.php';
 
+use AddArchivedAtToParticipationTable;
 use AddIsEncryptedToMessagesTable;
 use AddNameToConversationsTable;
 use AddReactionsToMessages;
@@ -66,6 +68,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
         (new AddIsEncryptedToMessagesTable)->up();
         (new AddReactionsToMessages)->up();
         (new AddNameToConversationsTable)->up();
+        (new AddArchivedAtToParticipationTable)->up();
         (new CreateTestTables)->up();
 
         $this->withFactories(__DIR__ . '/Helpers/factories');
@@ -119,6 +122,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
     protected function tearDown(): void
     {
+        (new AddArchivedAtToParticipationTable)->down();
         (new AddNameToConversationsTable)->down();
         (new AddReactionsToMessages)->down();
         (new AddIsEncryptedToMessagesTable)->down();

--- a/tests/Unit/ConversationArchiveTest.php
+++ b/tests/Unit/ConversationArchiveTest.php
@@ -31,13 +31,20 @@ class ConversationArchiveTest extends TestCase
         $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
 
         Chat::conversation($conversation)->setParticipant($this->alpha)->archive();
-        $first = Chat::conversation($conversation)->getParticipation($this->alpha)->archived_at;
+        $first = Chat::conversation($conversation)->getParticipation($this->alpha);
 
-        // Re-archive should not change archived_at timestamp
+        // Re-archive should be a no-op: neither archived_at nor updated_at should move.
         Chat::conversation($conversation)->setParticipant($this->alpha)->archive();
-        $second = Chat::conversation($conversation)->getParticipation($this->alpha)->archived_at;
+        $second = Chat::conversation($conversation)->getParticipation($this->alpha);
 
-        $this->assertEquals($first->toDateTimeString(), $second->toDateTimeString());
+        $this->assertTrue(
+            $first->archived_at->equalTo($second->archived_at),
+            'archived_at must not change on a no-op re-archive'
+        );
+        $this->assertTrue(
+            $first->updated_at->equalTo($second->updated_at),
+            'updated_at must not change on a no-op re-archive (the row should not be re-saved)'
+        );
     }
 
     public function test_unarchive_restores_a_conversation()

--- a/tests/Unit/ConversationArchiveTest.php
+++ b/tests/Unit/ConversationArchiveTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Musonza\Chat\Tests;
+
+use Chat;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Musonza\Chat\Models\Conversation;
+use Musonza\Chat\Models\Participation;
+
+class ConversationArchiveTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    public function test_a_participant_can_archive_a_conversation()
+    {
+        /** @var Conversation $conversation */
+        $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
+
+        Chat::conversation($conversation)->setParticipant($this->alpha)->archive();
+
+        $alphaParticipation = Chat::conversation($conversation)->getParticipation($this->alpha);
+        $bravoParticipation = Chat::conversation($conversation)->getParticipation($this->bravo);
+
+        $this->assertNotNull($alphaParticipation->archived_at);
+        $this->assertTrue($alphaParticipation->isArchived());
+        $this->assertNull($bravoParticipation->archived_at, 'Archive must not bleed into other participants');
+    }
+
+    public function test_archiving_is_idempotent()
+    {
+        $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
+
+        Chat::conversation($conversation)->setParticipant($this->alpha)->archive();
+        $first = Chat::conversation($conversation)->getParticipation($this->alpha)->archived_at;
+
+        // Re-archive should not change archived_at timestamp
+        Chat::conversation($conversation)->setParticipant($this->alpha)->archive();
+        $second = Chat::conversation($conversation)->getParticipation($this->alpha)->archived_at;
+
+        $this->assertEquals($first->toDateTimeString(), $second->toDateTimeString());
+    }
+
+    public function test_unarchive_restores_a_conversation()
+    {
+        $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
+
+        Chat::conversation($conversation)->setParticipant($this->alpha)->archive();
+        Chat::conversation($conversation)->setParticipant($this->alpha)->unarchive();
+
+        $this->assertNull(
+            Chat::conversation($conversation)->getParticipation($this->alpha)->archived_at
+        );
+    }
+
+    public function test_archived_conversations_are_excluded_from_default_listing()
+    {
+        Chat::createConversation([$this->alpha, $this->bravo]);
+        $second = Chat::createConversation([$this->alpha, $this->charlie]);
+        Chat::createConversation([$this->alpha, $this->delta]);
+
+        Chat::conversation($second)->setParticipant($this->alpha)->archive();
+
+        $list = Chat::conversations()->setParticipant($this->alpha)->get();
+
+        $this->assertCount(2, $list);
+        $this->assertNotContains($second->id, $list->pluck('conversation_id')->all());
+    }
+
+    public function test_archived_filter_returns_only_archived()
+    {
+        Chat::createConversation([$this->alpha, $this->bravo]);
+        $archivedConv = Chat::createConversation([$this->alpha, $this->charlie]);
+
+        Chat::conversation($archivedConv)->setParticipant($this->alpha)->archive();
+
+        $list = Chat::conversations()->setParticipant($this->alpha)->archived()->get();
+
+        $this->assertCount(1, $list);
+        $this->assertEquals($archivedConv->id, $list->first()->conversation_id);
+    }
+
+    public function test_with_archived_returns_both_archived_and_non_archived()
+    {
+        Chat::createConversation([$this->alpha, $this->bravo]);
+        $archivedConv = Chat::createConversation([$this->alpha, $this->charlie]);
+        Chat::createConversation([$this->alpha, $this->delta]);
+
+        Chat::conversation($archivedConv)->setParticipant($this->alpha)->archive();
+
+        $list = Chat::conversations()->setParticipant($this->alpha)->withArchived()->get();
+
+        $this->assertCount(3, $list);
+    }
+
+    public function test_archive_does_not_affect_other_participants_listings()
+    {
+        $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
+
+        Chat::conversation($conversation)->setParticipant($this->alpha)->archive();
+
+        // Bravo still sees it in their default inbox
+        $bravoList = Chat::conversations()->setParticipant($this->bravo)->get();
+        $this->assertCount(1, $bravoList);
+        $this->assertEquals($conversation->id, $bravoList->first()->conversation_id);
+    }
+
+    public function test_new_message_auto_unarchives_recipient_by_default()
+    {
+        $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
+
+        Chat::conversation($conversation)->setParticipant($this->alpha)->archive();
+
+        Chat::message('hi alpha')->from($this->bravo)->to($conversation)->send();
+
+        $alphaParticipation = Chat::conversation($conversation)->getParticipation($this->alpha);
+        $this->assertNull($alphaParticipation->archived_at, 'Recipient should be auto-unarchived on new message');
+    }
+
+    public function test_auto_unarchive_does_not_affect_sender()
+    {
+        $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
+
+        Chat::conversation($conversation)->setParticipant($this->alpha)->archive();
+
+        // Alpha (the archiver) sends a message themselves; their archive should remain.
+        Chat::message('still archived from my side')->from($this->alpha)->to($conversation)->send();
+
+        $alphaParticipation = Chat::conversation($conversation)->getParticipation($this->alpha);
+        $this->assertNotNull($alphaParticipation->archived_at, 'Sender archive should not be cleared by their own message');
+    }
+
+    public function test_auto_unarchive_can_be_disabled_via_config()
+    {
+        $this->app['config']->set('musonza_chat.unarchive_on_new_message', false);
+
+        $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
+
+        Chat::conversation($conversation)->setParticipant($this->alpha)->archive();
+
+        Chat::message('hi alpha')->from($this->bravo)->to($conversation)->send();
+
+        $alphaParticipation = Chat::conversation($conversation)->getParticipation($this->alpha);
+        $this->assertNotNull($alphaParticipation->archived_at, 'Recipient must remain archived when feature is disabled');
+    }
+
+    public function test_archive_no_op_for_non_participant()
+    {
+        $conversation = Chat::createConversation([$this->alpha, $this->bravo]);
+
+        // charlie is not a participant — must not throw and must not insert a row
+        $conversation->archive($this->charlie);
+
+        $this->assertEquals(2, Participation::where('conversation_id', $conversation->id)->count());
+    }
+
+    public function test_participation_scopes()
+    {
+        $conv1 = Chat::createConversation([$this->alpha, $this->bravo]);
+        Chat::createConversation([$this->alpha, $this->charlie]);
+
+        Chat::conversation($conv1)->setParticipant($this->alpha)->archive();
+
+        $this->assertEquals(1, Participation::query()->archived()
+            ->where('messageable_id', $this->alpha->getKey())
+            ->where('messageable_type', $this->alpha->getMorphClass())
+            ->count());
+
+        $this->assertEquals(1, Participation::query()->notArchived()
+            ->where('messageable_id', $this->alpha->getKey())
+            ->where('messageable_type', $this->alpha->getMorphClass())
+            ->count());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a Mail-style **archive** primitive at the **participation** level, so a single recipient can hide a conversation from their inbox without affecting other participants. Closes #361.
- New `archived_at` column on `chat_participation` (nullable, indexed). Migration is additive — existing rows get `NULL`.
- New API:
  - On `Participation`: `archive()`, `unarchive()`, `isArchived()`, scopes `archived` / `notArchived`.
  - On `Conversation`: `archive(Model $participant)`, `unarchive(Model $participant)`.
  - Fluent on `ConversationService`: `Chat::conversation(...)->setParticipant(...)->archive() / ->unarchive()` and `Chat::conversations()->setParticipant(...)->archived() / ->withArchived()->get()`.
- Default listing in `getConversationsList` excludes archived rows; `archived()` returns only archived; `withArchived()` returns both.
- Auto-unarchive: a new message in an archived conversation clears `archived_at` for the recipient(s) only — never the sender. Gated by `musonza_chat.unarchive_on_new_message` (default `true`).
- README updated with a new "Archive a conversation (per participant)" section.

## Backward compatibility
- Migration only adds a nullable column.
- New methods on `Participation`, `Conversation`, and `ConversationService` are additive.
- `getConversationsList`'s new default ("exclude archived") is a no-op for existing data because no rows have `archived_at` set.
- Auto-unarchive on `MessageNotification::createCustomNotifications` only fires when at least one recipient is archived, and is gated by config.
- The existing per-participant `clear()` behavior is left untouched and remains a separate, destructive operation.

## Test plan
- [ ] `vendor/bin/phpunit --filter ConversationArchiveTest` passes
- [ ] `vendor/bin/phpunit` full suite passes (no regression in `ConversationTest`, `MessageTest`, `NotificationsTest`)
- [ ] `php artisan migrate` then `php artisan migrate:rollback` runs cleanly against the new migration on a real DB (sqlite + mysql)
- [ ] Manually verify in tinker: archiving on side A leaves the conversation visible on side B, and a new B→A message reappears the thread for A
- [ ] Manually verify `unarchive_on_new_message => false` in `config/musonza_chat.php` keeps recipient archived after a new message