### PR TITLE
Publish the conversation name migration with the other chat migrations

### DIFF
--- a/src/ChatServiceProvider.php
+++ b/src/ChatServiceProvider.php
@@ -68,10 +68,14 @@ class ChatServiceProvider extends ServiceProvider
         $reactionsStub   = __DIR__ . '/../database/migrations/add_reactions_to_messages.php';
         $reactionsTarget = $this->app->databasePath() . '/migrations/' . $timestamp . '_add_reactions_to_messages.php';
 
+        $nameStub   = __DIR__ . '/../database/migrations/add_name_to_conversations_table.php';
+        $nameTarget = $this->app->databasePath() . '/migrations/' . $timestamp . '_add_name_to_conversations_table.php';
+
         $this->publishes([
             $stub           => $target,
             $encryptionStub => $encryptionTarget,
             $reactionsStub  => $reactionsTarget,
+            $nameStub       => $nameTarget,
         ], 'chat.migrations');
     }
 


### PR DESCRIPTION
The package code already expects a name column on conversations, but the provider only publishes a subset of migrations. This change adds the missing migration to the published set so apps get the schema needed for conversation creation