### PR TITLE
ci: drop EOL Laravel 10/11 from test matrix; publish archived_at migration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,13 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.2, 8.3, 8.4]
-        laravel: ['10.*', '11.*', '12.*', '13.*']
-        exclude:
-          - php: 8.2
-            laravel: 12.*
-          - php: 8.2
-            laravel: 13.*
+        php: [8.3, 8.4]
+        laravel: ['12.*', '13.*']
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,14 @@
     ],
     "require": {
         "php": ">=8.0",
-        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
-        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/contracts": "^12.0|^13.0",
+        "illuminate/support": "^12.0|^13.0",
         "spatie/laravel-fractal": "^6.0|dev-main",
         "laravel/legacy-factories": "^1.0|dev-master"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0|^10.5|^11.5.3|^12.5.12",
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
+        "orchestra/testbench": "^10.0|^11.0",
         "mockery/mockery": "^1.0.0",
         "larastan/larastan": "^2.0|^3.0|dev-l13",
         "laravel/pint": "^1.0"

--- a/src/ChatServiceProvider.php
+++ b/src/ChatServiceProvider.php
@@ -71,11 +71,15 @@ class ChatServiceProvider extends ServiceProvider
         $nameStub   = __DIR__ . '/../database/migrations/add_name_to_conversations_table.php';
         $nameTarget = $this->app->databasePath() . '/migrations/' . $timestamp . '_add_name_to_conversations_table.php';
 
+        $archivedAtStub   = __DIR__ . '/../database/migrations/add_archived_at_to_participation_table.php';
+        $archivedAtTarget = $this->app->databasePath() . '/migrations/' . $timestamp . '_add_archived_at_to_participation_table.php';
+
         $this->publishes([
             $stub           => $target,
             $encryptionStub => $encryptionTarget,
             $reactionsStub  => $reactionsTarget,
             $nameStub       => $nameTarget,
+            $archivedAtStub => $archivedAtTarget,
         ], 'chat.migrations');
     }
 


### PR DESCRIPTION
## Why CI is red

The **Laravel 10.\*** and **11.\*** jobs fail at the `composer update` step, before any test runs. Recent Composer refuses to install packages with open security advisories, and by now every remaining Laravel 10/11 release is advisory-flagged (both lines are past their security-EOL — L10 ~Feb 2025, L11 ~Mar 2026). The solver therefore has **no installable `laravel/framework` candidate** for those matrix rows and aborts with exit code 2. Laravel 12/13 are recent enough to be unaffected, which is why only those jobs pass. This is external Packagist state drift, unrelated to any code change.

## What this does

Drop the EOL versions instead of masking the advisory block:

- **`.github/workflows/tests.yml`** — remove `10.*`/`11.*` (and PHP 8.2, which `orchestra/testbench` for L12/L13 requires ≥8.3) from the matrix. The remaining 4 jobs are exactly the ones already green.
- **`composer.json`** — narrow `illuminate/contracts` + `illuminate/support` to `^12.0|^13.0`, and `orchestra/testbench` to `^10.0|^11.0` (testbench 7–9 map to the dropped Laravel 9–11).

## Also: publish the `archived_at` migration

`add_archived_at_to_participation_table.php` was added in #361 and the package code depends on the `archived_at` column (Participation model scopes/`archive()`, the conversation listing query, MessageNotification), but the provider never added it to the published migration set. This adds it, so fresh installs get the schema. Same class of fix as #364 (which adds the `name` migration).

> Note: overlaps #364 on the `publishes([...])` array — expect a trivial keep-both merge conflict whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)